### PR TITLE
Changed active master to master of selected layer

### DIFF
--- a/Components/Align All Components.py
+++ b/Components/Align All Components.py
@@ -7,13 +7,12 @@ Fakes auto-alignment in glyphs that cannot be auto-aligned.
 import GlyphsApp
 
 thisFont = Glyphs.font # frontmost font
-thisFontMaster = thisFont.selectedFontMaster # active master
-thisFontMasterID = thisFont.selectedFontMaster.id # active master
 listOfSelectedLayers = thisFont.selectedLayers # active layers of selected glyphs
 
 def process( thisLayer ):
 	advance = 0.0
 	for thisComponent in thisLayer.components:
+		thisFontMasterID = thisLayer.layerId
 		thisComponent.position = NSPoint( advance, 0.0 )
 		advance += thisComponent.component.layers[thisFontMasterID].width
 	thisLayer.width = advance


### PR DESCRIPTION
Need to distinguish between active master when selecting glyphs across different masters in the same text tab.
(Though maybe it would break if selecting a bracket layer?)