### PR TITLE
Fix reset image transform script

### DIFF
--- a/Images/Reset Image Transformation.py
+++ b/Images/Reset Image Transformation.py
@@ -9,8 +9,9 @@ Font = Glyphs.font
 selectedLayers = Font.selectedLayers
 
 def process( thisLayer ):
-	thisImage = thisLayer.backgroundImage()
-	thisImage.setTransformStruct_( (1.0, 0.0, 0.0, 1.0, 0.0, 0.0) )
+	thisImage = thisLayer.backgroundImage
+	if thisImage:
+		thisImage.transform = ((1.0, 0.0, 0.0, 1.0, 0.0, 0.0))
 
 Font.disableUpdateInterface()
 


### PR DESCRIPTION
The reset image transform script didn't work with Glyphs 2.5.2 (1150). This is updated using the latest docs, and also doesn't crash if a selected glyph doesn't have a background image.