### PR TITLE
use quoted name to work with more name formats

### DIFF
--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -522,7 +522,7 @@ htmlContent = """<head>
 	function changeFont() {
 		var selected_index = selector.selectedIndex;
 		var selected_option_text = selector.options[selected_index].text;
-		document.getElementById('waterfall').style.fontFamily = selected_option_text;
+		document.getElementById('waterfall').style.fontFamily = `'${selected_option_text}'`;
 	}
 	function setDefaultText(defaultText) {
 		document.getElementById('textInput').value = decodeEntities(defaultText);


### PR DESCRIPTION
e.g. my 

`@font-face { font-family: 'OTF Neutronic v0.8-Extralight'; src: url('Neutronicv0.8-Extralight.otf'); }`

style did only work when making this change.