### PR TITLE
Fix Straight Stem Cruncher

### DIFF
--- a/Paths/Straight Stem Cruncher.py
+++ b/Paths/Straight Stem Cruncher.py
@@ -313,7 +313,9 @@ class StraightStemCruncher(object):
 		centers = []
 		measurements = []
 		measureLayer = layer.copyDecomposedLayer()
+		measureLayer.parent = layer.parent
 		measureLayer.removeOverlap()
+
 		for thisPath in measureLayer.paths:
 			nodeCount = len(thisPath.nodes)
 			if nodeCount > 2:
@@ -411,8 +413,10 @@ class StraightStemCruncher(object):
 								# decompose components if necessary:
 								if Glyphs.defaults["com.mekkablue.StraightStemCruncher.includeCompounds"]:
 									checkLayer = thisLayer.copyDecomposedLayer()
+									checkLayer.parent = thisLayer.parent
 								else:
 									checkLayer = thisLayer.copy()
+									checkLayer.parent = thisLayer.parent
 									if Glyphs.versionNumber >= 3:
 										# Glyphs 3 code
 

--- a/Paths/Straight Stem Cruncher.py
+++ b/Paths/Straight Stem Cruncher.py
@@ -283,8 +283,8 @@ class StraightStemCruncher(object):
 
 		if len(intersections) > 2:
 			# two measurement points:
-			p1 = intersections[1].pointValue()
-			p2 = intersections[2].pointValue()
+			p1 = intersections[0].pointValue()
+			p2 = intersections[1].pointValue()
 
 			# calculate stem width:
 			stemWidth = distance(p1, p2)

--- a/Paths/Straight Stem Cruncher.py
+++ b/Paths/Straight Stem Cruncher.py
@@ -330,15 +330,18 @@ class StraightStemCruncher(object):
 
 						if isHorizontal and checkHStems:
 							check = True
+
 						elif isVertical and checkVStems:
 							check = True
+
 						elif checkDStems:
 							check = True
 
 						#if p1.x==p2.x or p1.y==p2.y or not Glyphs.defaults["com.mekkablue.StraightStemCruncher.ignoreDiagonals"]:
 						if check:
 							if pointDistance(p1, p2) >= minLength:
-								results = self.stemThicknessAtLine(measureLayer, p1, p2, measureLength=max(100.0, measureLayer.bounds.size.width + measureLayer.bounds.size.height))
+								measureLength=max(100.0, measureLayer.bounds.size.width + measureLayer.bounds.size.height)
+								results = self.stemThicknessAtLine(measureLayer, p1, p2, measureLength)
 								if results:
 									measurement, centerOfStem = results
 									measurements.append(measurement)

--- a/Paths/Straight Stem Cruncher.py
+++ b/Paths/Straight Stem Cruncher.py
@@ -259,7 +259,7 @@ class StraightStemCruncher(object):
 
 		return True
 
-	def stemThicknessAtLine(self, layer, p1, p2, measureLength=100.0):
+	def stemThicknessAtLine(self, layer, p1, p2, measureLength):
 		h = p2.x - p1.x
 		v = p2.y - p1.y
 		l = (h**2 + v**2)**0.5


### PR DESCRIPTION
Fixed some problems that are described here: https://forum.glyphsapp.com/t/problems-with-mekkablue-s-straight-stem-cruncher/28190/3

The calculation of stems did not work, because the paths bounding box was not returned correctly. This was fixed by assigning the original layer’s parent to the orphaned decomposed copy.
Another problem was the measurement of the stems: here the remainder of the measuring line was used. I fixed this by correcting the indexes to use the first and second instead of the second and third.