### PR TITLE
"Change Metrics by Percentage" – make it work when glyphs are used as components, without anchor attachment

### DIFF
--- a/Spacing/Change Metrics by Percentage.py
+++ b/Spacing/Change Metrics by Percentage.py
@@ -77,14 +77,20 @@ class ChangeMetricsbyPercentage(mekkaObject):
 
 						LSB_change = (thisLayer.LSB * change) - thisLayer.LSB
 
-						print(thisLayer.parent.name, layer_id, "LSB:", thisLayer.LSB, "->", thisLayer.LSB * change, " | change of", LSB_change)
 						thisLayer.LSB *= change
 
 						# counteract movement in glyphs that reference this glyph as a component:
 						for g in self.findGlyphsThatReferenceGlyphAsComponent(thisLayer.parent):
 							for c in g.layers[layer_id].components:
 								if c.componentName == thisLayer.parent.name:
-									c.position = (c.position[0] - LSB_change, c.position[1])
+
+									# if component is rotated or mirrored, we need to reverse the LSB change
+									if c.transform[0] < 0 or c.transform[3] < 0:
+										c.position = (c.position[0] + LSB_change, c.position[1])
+
+									# otherwise, we can just offset the LSB change directly
+									else:
+										c.position = (c.position[0] - LSB_change, c.position[1])
 
 
 					if changeRSB:

--- a/Spacing/Change Metrics by Percentage.py
+++ b/Spacing/Change Metrics by Percentage.py
@@ -49,6 +49,14 @@ class ChangeMetricsbyPercentage(mekkaObject):
 		self.w.open()
 		self.w.makeKey()
 
+	def findGlyphsThatReferenceGlyphAsComponent(self, glyph):
+		Font = Glyphs.font
+		glyphs = []
+		for g in Font.glyphs:
+			if g != glyph and glyph.name in [c.componentName for c in g.layers[0].components]:
+				glyphs.append(g)
+		return glyphs
+
 	def ChangeMetricsbyPercentageMain(self, sender):
 		try:
 			Font = Glyphs.font
@@ -62,9 +70,23 @@ class ChangeMetricsbyPercentage(mekkaObject):
 				change = 1.0 / change
 
 			for thisLayer in selectedLayers:
+
+				layer_id = thisLayer.layerId
 				if len(thisLayer.paths) > 0 or len(thisLayer.components) > 0:
 					if changeLSB:
+
+						LSB_change = (thisLayer.LSB * change) - thisLayer.LSB
+
+						print(thisLayer.parent.name, layer_id, "LSB:", thisLayer.LSB, "->", thisLayer.LSB * change, " | change of", LSB_change)
 						thisLayer.LSB *= change
+
+						# counteract movement in glyphs that reference this glyph as a component:
+						for g in self.findGlyphsThatReferenceGlyphAsComponent(thisLayer.parent):
+							for c in g.layers[layer_id].components:
+								if c.componentName == thisLayer.parent.name:
+									c.position = (c.position[0] - LSB_change, c.position[1])
+
+
 					if changeRSB:
 						thisLayer.RSB *= change
 


### PR DESCRIPTION
## Problem

"Change Metrics by Percentage" and "Adjust Sidebearings" break alignment on glyphs that use a base glyph as a component, plus a drawn contour. 

For example, both scripts have a problem here:

<img width="770" alt="Image" src="https://github.com/user-attachments/assets/2a64e441-4901-4e6c-8cb3-2773124679db" />

<img width="1136" alt="Image" src="https://github.com/user-attachments/assets/fa91b13e-23f1-4aaf-b46b-6f9dc4febf5b" />

I want to start by saying that I didn’t draw this font, and I think it’s a bit of a surprising specific example to see an /h drawn with an /n component plus a rectangle contour. Still, I do sometimes mix components and drawn contours, in glyphs such as /hbar (/h component, drawn bar), and it’s probably a relatively common practice.

Basically, the /n glyph gets updated spacing, it also moves over as a component in /h, misaligning it from the ascender rectangle.

## Proposed potential solution

This PR updates "Change Metrics by Percentage" to find where a layer is referenced, and adjusts that component positioning to account for sidebearing changes to the parent.

It also looks for reflected components and reverses the positioning adjustment, in cases such as a /p being used for the /q, and the /q being used in /qhook.

<img width="1398" alt="image" src="https://github.com/user-attachments/assets/2ed74fb4-3e1a-4e1f-8aac-e537c6bdd6df" />

## Current problems

This script is much slower than the original, because it loops over the full font many times. It takes maybe 10 seconds to run on 850 glyphs. So, it could probably be much more efficient.

This script probably doesn’t solve for RTL scripts well, as it only adjusts components based on LSB changes.

This PR only changes "Change Metrics by Percentage", but the problem also exists in "Adjust Sidebearings," which is probably more widely used. (I certainly use it more often.)

## Why I’m submitting this PR

I’m mostly submitting this as something of a more direct issue report. I’m also partly submitting it as a way to track the version of the script I used in a current particular project.

I will try to improve this further, if time or necessity permits. Also, though, I very much welcome edits by maintainers. Or, if it’s obvious to you how to correct for this, without this PR, I am happy for this PR to be closed in favor of a faster change.

Thanks so much!

