### PR TITLE
Fixed Copy Layer to Layer (Enhanced) X.py Incorrect Master and Layer Displayed

### DIFF
--- a/Interpolation/Copy Layer to Layer (Enhanced) X.py
+++ b/Interpolation/Copy Layer to Layer (Enhanced) X.py
@@ -115,12 +115,16 @@ class CopyLayerToLayer(mekkaObject):
 		self.w.runButton = vanilla.Button((-120 - inset, -20 - inset, -inset, -inset), "Copy Layers", sizeStyle='regular', callback=self.CopyLayerToLayerMain)
 		self.w.setDefaultButton(self.w.runButton)
 
+		# Load Settings:
+		self.LoadPreferences()
+
 		# Update the layer popups after fonts are loaded
 		self.UpdateSourceLayers(None)
 		self.UpdateTargetLayers(None)
 
-		# Load Settings:
-		self.LoadPreferences()
+		# Now manually restore just the layer popup indices:
+		self.w.sourceLayerPopup.set(self.pref("sourceLayerPopup"))
+		self.w.targetLayerPopup.set(self.pref("targetLayerPopup"))
 
 		# Open window and focus on it:
 		self.w.open()


### PR DESCRIPTION
Fix layer popup preference restore order

LoadPreferences() sets all popup indices in one pass, but the layer popups depend on the font popups to populate their contents. Since setting a font popup index doesn't trigger its callback, the layer lists are still stale when their saved indices are applied — causing source and target layers to silently point to the wrong items.

Fixed by explicitly rebuilding the layer lists after preferences load, then restoring the layer indices against the correct lists.