### PR TITLE
Paths/Position Clicker: fix crash when referenceLayer is None

### DIFF
--- a/Paths/Position Clicker.py
+++ b/Paths/Position Clicker.py
@@ -246,6 +246,8 @@ class PositionClicker(mekkaObject):
 								if (thisLayer.isMasterLayer or thisLayer.isSpecialLayer) and (thisLayer.paths or includeComposites):
 									comboCount += 1
 									referenceLayer = referenceGlyph.layers[thisLayer.master.id]
+									if referenceLayer is None:
+										continue
 									if (comesFirst and isRTL) or (comesLater and not isRTL):
 										if not doTheyClick(referenceLayer, thisLayer, clickCount, verbose):
 											tabLayers.append(referenceLayer)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `referenceGlyph.layers[masterId]` can return `None` when the reference glyph has no layer for a given master ID (e.g. special/brace layers whose master doesn't exist in the reference glyph).
- This caused an `AttributeError: 'NoneType' object has no attribute 'copyDecomposedLayer'` crash in `doTheyClick()`.
- Fix: skip the iteration with `continue` when `referenceLayer is None`.

## Test plan

- [ ] Run Position Clicker on a font with special layers or masters where the reference glyph (`behDotless-ar.medi`) lacks a matching layer — confirm no crash.
- [ ] Verify normal clicking/non-clicking detection still works correctly across all masters.

https://claude.ai/code/session_01XKzrPRKDWucqtxFEszNfFF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKzrPRKDWucqtxFEszNfFF)_