### PR TITLE
Fix AttributeError when closing Find and Replace Components window

### DIFF
--- a/Components/Find and Replace Components.py
+++ b/Components/Find and Replace Components.py
@@ -157,8 +157,8 @@ class FindReplaceComponents(mekkaObject):
 
 	def updateUI(self, sender=None):
 		try:
-			findName = self.w.findName.get()
-			replaceName = self.w.replaceName.get()
+			findName = self.w.findName.get() or ""
+			replaceName = self.w.replaceName.get() or ""
 		except Exception:
 			return
 


### PR DESCRIPTION
## Summary

- When the window closes, vanilla fires a `controlTextDidEndEditing_` callback on the ComboBox, which calls `findChanged` → `updateUI()`
- At that point, `self.w.replaceName.get()` (and potentially `findName`) can return `None`
- Calling `.strip()` on `None` raises `AttributeError: 'NoneType' object has no attribute 'strip'`
- Fix: coerce both values to empty string with `or ""` immediately after `.get()`

## Test plan

- [ ] Open Find and Replace Components
- [ ] Type something in the Find field
- [ ] Close the window — confirm no error appears in the Macro Window

https://claude.ai/code/session_011hJbjdBAoT4uYfsPMM7oXn

---
_Generated by [Claude Code](https://claude.ai/code/session_011hJbjdBAoT4uYfsPMM7oXn)_