### PR TITLE
Call font.currentTab.reflow() after Compatibility Manager actions

### DIFF
--- a/Interpolation/Compatibility Manager 2.py
+++ b/Interpolation/Compatibility Manager 2.py
@@ -482,6 +482,9 @@ class CompatibilityManager2(mekkaObject):
 		finally:
 			font.enableUpdateInterface()
 
+		if font.currentTab:
+			font.currentTab.reflow()
+
 		if doOpenTab and incompatible:
 			font.newTab("/" + "/".join(name for name, _ in incompatible))
 

--- a/Interpolation/Compatibility Manager.py
+++ b/Interpolation/Compatibility Manager.py
@@ -166,6 +166,8 @@ class CompatibilityManager:
 			self.updateCompatibility(glyph)
 		
 		self.updateViews()
+		if font.currentTab:
+			font.currentTab.reflow()
 
 	def findOptimalStartPoint(self, layer, pathIndex, startPointOption):
 		path = layer.shapes[pathIndex]
@@ -235,6 +237,8 @@ class CompatibilityManager:
 			self.reorderShapesByShortestTravel(glyph)
 
 		self.updateCompatibility(glyph)
+		if font.currentTab:
+			font.currentTab.reflow()
 
 	def reorderShapesBySize(self, glyph):
 		layers = [layer for layer in glyph.layers if layer.isMasterLayer or layer.isSpecialLayer]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- In **Compatibility Manager.py**: added `if font.currentTab: font.currentTab.reflow()` at the end of both `resetStartPoints` and `reorderShapes` methods.
- In **Compatibility Manager 2.py**: added the same guard+call in the `run` method, immediately after `font.enableUpdateInterface()` completes.

This ensures the edit view reflowes after changes are applied, so node positions update visually without requiring a manual interaction.

## Test plan

- [ ] Open a font with multiple masters in Glyphs
- [ ] Select a glyph with an open Edit tab
- [ ] Run **Compatibility Manager** → Reset Start Points → confirm the edit view updates immediately
- [ ] Run **Compatibility Manager** → Reorder Shapes → confirm the edit view updates immediately
- [ ] Run **Compatibility Manager 2** → confirm the edit view updates after Run completes
- [ ] Verify no crash when running with no tab open (currentTab guard)

https://claude.ai/code/session_0133ge3CaEQ2R7SwNMs6zh5h
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0133ge3CaEQ2R7SwNMs6zh5h)_