### PR TITLE
Add currentTab.reflow() to all scripts that update the edit view

### DIFF
--- a/Anchors/Insert All Anchors in All Layers.py
+++ b/Anchors/Insert All Anchors in All Layers.py
@@ -141,6 +141,7 @@ try:
 		# thisGlyph.endUndo()  # undo grouping causes crashes
 	if thisFont.currentTab and thisFont.currentTab.graphicView():
 		thisFont.currentTab.graphicView().redraw()
+		thisFont.currentTab.reflow()
 except Exception as e:
 	Glyphs.showMacroWindow()
 	print("\n⚠️ Script Error:\n")

--- a/App/Line Height Decrease.py
+++ b/App/Line Height Decrease.py
@@ -22,5 +22,6 @@ if not lineheight < 100.0:
 	Font.customParameters[parameterName] = lineheight
 	if Font.currentTab:
 		Font.currentTab.forceRedraw()
+		Font.currentTab.reflow()
 else:
 	Message(title="Line Height Error", message="The line height is already below 100 units. Cannot decrease any further.", OKButton=None)

--- a/App/Line Height Increase.py
+++ b/App/Line Height Increase.py
@@ -22,5 +22,6 @@ if not lineheight > Font.upm * 10:
 	Font.customParameters[parameterName] = lineheight
 	if Font.currentTab:
 		Font.currentTab.forceRedraw()
+		Font.currentTab.reflow()
 else:
 	Message(title="Line Height Error", message="The line height exceeds the UPM more than tenfold already. Stop it now.", OKButton=None)

--- a/Components/Component Mover.py
+++ b/Components/Component Mover.py
@@ -253,6 +253,7 @@ class ComponentMover(mekkaObject):
 
 				if thisFont.currentTab:
 					thisFont.currentTab.redraw()
+					thisFont.currentTab.reflow()
 					# NSNotificationCenter.defaultCenter().postNotificationName_object_("GSUpdateInterface", thisFont.currentTab)
 				else:
 					thisFont.fontView.redraw()

--- a/Components/Move Paths to Component.py
+++ b/Components/Move Paths to Component.py
@@ -321,6 +321,8 @@ class MovePathstoComponent(mekkaObject):
 			# trigger UI update:
 			if Glyphs.versionNumber >= 3 and thisFont.currentTab:
 				NSNotificationCenter.defaultCenter().postNotificationName_object_("GSUpdateInterface", thisFont.currentTab)
+			if thisFont.currentTab:
+				thisFont.currentTab.reflow()
 
 			# Final report:
 			if glyphName:

--- a/Components/Propagate Corner Components to Other Masters.py
+++ b/Components/Propagate Corner Components to Other Masters.py
@@ -65,3 +65,5 @@ if thisFont and selectedLayers:
 		if Glyphs.versionNumber < 3 and thisFont.currentTab:
 			thisFont.currentTab.redraw()
 			# NSNotificationCenter.defaultCenter().postNotificationName_object_("GSUpdateInterface", thisFont.currentTab)
+		if thisFont.currentTab:
+			thisFont.currentTab.reflow()

--- a/Font Info/Batch-Import Masters.py
+++ b/Font Info/Batch-Import Masters.py
@@ -209,6 +209,8 @@ class BatchImportMasters(mekkaObject):
 					font.enableUpdateInterface()
 					for thisUI in (font.currentTab, font.fontView):
 						NSNotificationCenter.defaultCenter().postNotificationName_object_("GSUpdateInterface", thisUI)
+					if font.currentTab:
+						font.currentTab.reflow()
 					print("\n✅ Done.")
 					if not self.pref("suppressMessage"):
 						Message(

--- a/Interpolation/Brace Layer Manager.py
+++ b/Interpolation/Brace Layer Manager.py
@@ -157,6 +157,8 @@ class BraceLayerManager(mekkaObject):
 					thisFont.enableUpdateInterface()  # re-enables UI updates in Font View
 					if thisFont.currentTab and Glyphs.versionNumber >= 3:
 						NSNotificationCenter.defaultCenter().postNotificationName_object_("GSUpdateInterface", thisFont.currentTab)
+					if thisFont.currentTab:
+						thisFont.currentTab.reflow()
 			print()
 
 		# Final report:

--- a/Interpolation/Travel Tracker.py
+++ b/Interpolation/Travel Tracker.py
@@ -24,6 +24,7 @@ def setCurrentTabToShowAllInstances(font):
 		previewingTab.setSelectedInstance_(-1)
 		previewingTab.updatePreview()
 		previewingTab.forceRedraw()
+		previewingTab.reflow()
 		font.tool = "TextTool"
 		previewingTab.textCursor = 0
 	except Exception as e:

--- a/Paths/Green Blue Manager.py
+++ b/Paths/Green Blue Manager.py
@@ -363,6 +363,7 @@ class GreenBlueManager(mekkaObject):
 					if numberOfLayers == 1 and len(glyphsToBeProcessed) != 1 and thisFont.currentTab:
 						# if only one layer was processed, do not open new tab:
 						thisFont.currentTab.forceRedraw()
+						thisFont.currentTab.reflow()
 						if affectedLayersFixedConnections or affectedLayersRealignedHandles:
 							message = ""
 							if affectedLayersFixedConnections:

--- a/Pixelfonts/Offset Pixel Rows.py
+++ b/Pixelfonts/Offset Pixel Rows.py
@@ -142,6 +142,7 @@ class OffsetPixelRows(mekkaObject):
 
 				if thisFont.currentTab:
 					thisFont.currentTab.redraw()
+					thisFont.currentTab.reflow()
 				else:
 					thisFont.fontView.redraw()
 	


### PR DESCRIPTION
## Summary

All scripts that already triggered an edit view update (via `forceRedraw()`, `redraw()`, `graphicView().redraw()`, or `GSUpdateInterface` notification) now also call `currentTab.reflow()` so the edit view reflowes immediately. A `currentTab is not None` guard is added wherever one was missing.

## Scripts updated

| File | Previous update method |
|---|---|
| `App/Line Height Increase.py` | `forceRedraw()` (already guarded) |
| `App/Line Height Decrease.py` | `forceRedraw()` (already guarded) |
| `Paths/Green Blue Manager.py` | `forceRedraw()` (already guarded) |
| `Anchors/Insert All Anchors in All Layers.py` | `graphicView().redraw()` (already guarded) |
| `Components/Component Mover.py` | `redraw()` (already guarded) |
| `Components/Move Paths to Component.py` | `GSUpdateInterface` notification (already guarded) |
| `Components/Propagate Corner Components to Other Masters.py` | `redraw()` for Glyphs 2 only — new guard added for reflow |
| `Font Info/Batch-Import Masters.py` | `GSUpdateInterface` notification — new guard added for reflow |
| `Interpolation/Brace Layer Manager.py` | `GSUpdateInterface` notification for Glyphs 3 only — new guard added for reflow |
| `Interpolation/Travel Tracker.py` | `forceRedraw()` (tab assumed non-nil by caller) |
| `Pixelfonts/Offset Pixel Rows.py` | `redraw()` (already guarded) |

https://claude.ai/code/session_0133ge3CaEQ2R7SwNMs6zh5h

---
_Generated by [Claude Code](https://claude.ai/code/session_0133ge3CaEQ2R7SwNMs6zh5h)_