### PR TITLE
Quote Manager: always preserve quotesingle if it already has content

### DIFF
--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -927,7 +927,7 @@ class QuoteManager(mekkaObject):
 					if singleName == defaultQuote:
 						continue
 					if singleName == "quotesingle" and "dumbQuotes" in groups:
-						self.buildDumbQuote(font, forceOverwrite=forceOverwrite)
+						self.buildDumbQuote(font, forceOverwrite=False)
 					else:
 						self.buildSingleFromDefault(font, singleName, defaultQuote, forceOverwrite=forceOverwrite)
 


### PR DESCRIPTION
## Summary

- `quotesingle` (the single dumb quote) is drawn by hand rather than derived from another quote shape, so it must never be overwritten by the Build action — even when "Preserve existing quotes" is turned off.
- Fixed by always passing `forceOverwrite=False` to `buildDumbQuote()` in the `build()` method, regardless of the global `preserveExisting` preference.
- All other quotes (left/right, base, guillemets, etc.) continue to respect the Preserve setting as before.

## Test plan

- [ ] Draw a custom `quotesingle`, then run Build with "Preserve existing quotes" **off** — verify `quotesingle` is unchanged.
- [ ] Leave `quotesingle` empty, run Build — verify it is drawn as a trapezoid.
- [ ] Confirm other quotes (e.g. `quoteright`) are still overwritten when Preserve is off.

https://claude.ai/code/session_01TqBz4DfMUHjGANfFxdNaDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqBz4DfMUHjGANfFxdNaDA)_