### PR TITLE
Quote Manager: Edit Singles also opens quotesingle when Dumb Quotes is on

### DIFF
--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -814,6 +814,10 @@ class QuoteManager(mekkaObject):
 						self.setAnchors(layer)
 						print(f"\t⚓ Added anchors to {defaultName} / {master.name}")
 
+			if self.prefBool("doDumbQuotes"):
+				self.ensureGlyphExists(font, "quotesingle")
+				glyphsToOpen.append("quotesingle")
+
 			self.openTabIfRequested(font, glyphsToOpen)
 			print("\nDone.")
 		except Exception as e:


### PR DESCRIPTION
## Summary

- When "Dumb Quotes" is checked, clicking **Edit Singles** now also creates `quotesingle` if it doesn't exist yet and includes it in the tab that opens.
- No anchors are set on `quotesingle` (it's a straight trapezoid, not a cursive-attachment glyph).

## Test plan

- [ ] Enable "Dumb Quotes", click Edit Singles — verify `quotesingle` appears in the opened tab.
- [ ] Disable "Dumb Quotes", click Edit Singles — verify `quotesingle` is not included.

https://claude.ai/code/session_01TqBz4DfMUHjGANfFxdNaDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqBz4DfMUHjGANfFxdNaDA)_