### PR TITLE
Find in Features: GLYPH OVERVIEW for wildcard searches

### DIFF
--- a/Features/Find in Features.py
+++ b/Features/Find in Features.py
@@ -7,6 +7,7 @@ Finds expressions (glyph, lookup or class names) in OT Features, Prefixes and Cl
 
 import vanilla
 from fnmatch import fnmatchcase
+from AppKit import NSFont, NSFontFeatureSettingsAttribute, NSFontFeatureTypeIdentifierKey, NSFontFeatureSelectorIdentifierKey
 from GlyphsApp import Glyphs
 from mekkablue import mekkaObject, UpdateButton, getLegibleFont
 
@@ -37,13 +38,27 @@ class FindInFeatures(mekkaObject):
 
 		self.w.result = vanilla.TextEditor((inset, linePos, -inset, -inset), "")
 		self.w.result.getNSTextView().setEditable_(False)
-		self.w.result.getNSTextView().setFont_(getLegibleFont())
+		self.w.result.getNSTextView().setFont_(self.legibleTabularFont())
 		self.w.result.getNSTextView().setToolTip_("Search results: OT classes, prefixes, and features that contain the searched name.")
 		linePos += lineHeight
 
 		# Open window and focus on it:
 		self.w.open()
 		self.w.makeKey()
+
+	def legibleTabularFont(self):
+		font = getLegibleFont()
+		try:
+			descriptor = font.fontDescriptor().fontDescriptorByAddingAttributes_({
+				NSFontFeatureSettingsAttribute: [{
+					NSFontFeatureTypeIdentifierKey: 6,   # Number Spacing
+					NSFontFeatureSelectorIdentifierKey: 0,  # Monospaced numbers
+				}]
+			})
+			font = NSFont.fontWithDescriptor_size_(descriptor, font.pointSize()) or font
+		except Exception:
+			pass
+		return font
 
 	def update(self, sender=None):
 		self.w.searchFor.setItems(self.glyphNamesAndClassNames())
@@ -87,14 +102,14 @@ class FindInFeatures(mekkaObject):
 			isWildcard = '*' in searchfor or '?' in searchfor
 
 			# Find in Classes:
-			classReportText = "OT Classes:\n"
+			classReportText = "OT CLASSES\n"
 			classes = []
 			for c in thisFont.classes:
 				if any(fnmatchcase(word, searchfor) for word in self.codeClean(c.code).split()):
 					classes.append(c.name)
 
 			if not classes:
-				classReportText += "(nothing found)\n"
+				classReportText += "\t(nothing found)\n"
 				classSet = None
 			else:
 				classSet = set(classes)
@@ -106,8 +121,8 @@ class FindInFeatures(mekkaObject):
 
 			# Find in Prefixes and Features:
 			prefixAndFeatures = (
-				(thisFont.featurePrefixes, "\nOT Prefixes:\n"),
-				(thisFont.features, "\nOT Features:\n"),
+				(thisFont.featurePrefixes, "\nOT PREFIXES\n"),
+				(thisFont.features, "\nOT FEATURES\n"),
 			)
 
 			glyphFeatures = {}  # {glyphName: [featureTag, ...]} — for the overview
@@ -140,14 +155,14 @@ class FindInFeatures(mekkaObject):
 										foundInFeaturesCount += 1
 
 				if foundInFeaturesCount == originalFeatureCount:
-					prefixFeatureReportText += "(nothing found)\n"
+					prefixFeatureReportText += "\t(nothing found)\n"
 
 			# Assemble report:
 			reportText = ""
 			if isWildcard and glyphFeatures:
 				reportText += "GLYPH OVERVIEW\n"
 				for glyphName in sorted(glyphFeatures.keys()):
-					reportText += "%s: %s\n" % (glyphName, ", ".join(glyphFeatures[glyphName]))
+					reportText += "\t%s: %s\n" % (glyphName, ", ".join(glyphFeatures[glyphName]))
 				reportText += "\n"
 			reportText += classReportText
 			reportText += prefixFeatureReportText

--- a/Features/Find in Features.py
+++ b/Features/Find in Features.py
@@ -79,59 +79,78 @@ class FindInFeatures(mekkaObject):
 
 	def FindInFeaturesMain(self, sender=None):
 		try:
-			reportText = ""
-
 			thisFont = Glyphs.font  # frontmost font
-			if thisFont is not None:
-				searchfor = sender.get()
+			if thisFont is None:
+				return
 
-				# Find in Classes:
-				reportText += "OT Classes:\n"
-				classes = []
-				for c in thisFont.classes:
-					if any(fnmatchcase(word, searchfor) for word in self.codeClean(c.code).split()):
-						classes.append(c.name)
+			searchfor = sender.get()
+			isWildcard = '*' in searchfor or '?' in searchfor
 
-				if not classes:
-					reportText += "(nothing found)\n"
-					classSet = None
-				else:
-					classSet = set(classes)
-					for className in classSet:
-						reportText += "\t%s" % className
-						if classes.count(className) > 1:
-							reportText += " (%i×)" % classes.count(className)
-						reportText += "\n"
+			# Find in Classes:
+			classReportText = "OT Classes:\n"
+			classes = []
+			for c in thisFont.classes:
+				if any(fnmatchcase(word, searchfor) for word in self.codeClean(c.code).split()):
+					classes.append(c.name)
 
-				# Find in Prefix and Features:
-				prefixAndFeatures = (
-					(thisFont.featurePrefixes, "\nOT Prefixes:\n"),
-					(thisFont.features, "\nOT Features:\n"),
-				)
+			if not classes:
+				classReportText += "(nothing found)\n"
+				classSet = None
+			else:
+				classSet = set(classes)
+				for className in classSet:
+					classReportText += "\t%s" % className
+					if classes.count(className) > 1:
+						classReportText += " (%i×)" % classes.count(className)
+					classReportText += "\n"
 
-				foundInFeaturesCount = 0
-				for featureSet in prefixAndFeatures:
-					originalFeatureCount = foundInFeaturesCount
-					reportText += featureSet[1]
-					for feature in featureSet[0]:
-						if feature.active:
-							cleanCode = self.codeClean(feature.code)
-							for i, l in enumerate(cleanCode.splitlines()):
-								split = l.split()
-								matchedWords = list(dict.fromkeys(w for w in split if fnmatchcase(w, searchfor)))
-								if matchedWords:
-									reportText += "\t%s, line %i (%s)\n" % (feature.name, i + 1, ", ".join(matchedWords))
-									foundInFeaturesCount += 1
+			# Find in Prefixes and Features:
+			prefixAndFeatures = (
+				(thisFont.featurePrefixes, "\nOT Prefixes:\n"),
+				(thisFont.features, "\nOT Features:\n"),
+			)
 
-								# also find the classes the term appears in:
-								if classSet:
-									for otclass in classSet:
-										if "@%s" % otclass in split:
-											reportText += "\t%s, line %i (@%s)\n" % (feature.name, i + 1, otclass)
-											foundInFeaturesCount += 1
+			glyphFeatures = {}  # {glyphName: [featureTag, ...]} — for the overview
+			prefixFeatureReportText = ""
+			foundInFeaturesCount = 0
+			for featureSet in prefixAndFeatures:
+				originalFeatureCount = foundInFeaturesCount
+				prefixFeatureReportText += featureSet[1]
+				for feature in featureSet[0]:
+					if feature.active:
+						cleanCode = self.codeClean(feature.code)
+						for i, l in enumerate(cleanCode.splitlines()):
+							split = l.split()
+							matchedWords = list(dict.fromkeys(w for w in split if fnmatchcase(w, searchfor)))
+							if matchedWords:
+								prefixFeatureReportText += "\t%s, line %i (%s)\n" % (feature.name, i + 1, ", ".join(matchedWords))
+								foundInFeaturesCount += 1
+								if isWildcard:
+									for w in matchedWords:
+										if w not in glyphFeatures:
+											glyphFeatures[w] = []
+										if feature.name not in glyphFeatures[w]:
+											glyphFeatures[w].append(feature.name)
 
-					if foundInFeaturesCount == originalFeatureCount:
-						reportText += "(nothing found)\n"
+							# also find the classes the term appears in:
+							if classSet:
+								for otclass in classSet:
+									if "@%s" % otclass in split:
+										prefixFeatureReportText += "\t%s, line %i (@%s)\n" % (feature.name, i + 1, otclass)
+										foundInFeaturesCount += 1
+
+				if foundInFeaturesCount == originalFeatureCount:
+					prefixFeatureReportText += "(nothing found)\n"
+
+			# Assemble report:
+			reportText = ""
+			if isWildcard and glyphFeatures:
+				reportText += "GLYPH OVERVIEW\n"
+				for glyphName in sorted(glyphFeatures.keys()):
+					reportText += "%s: %s\n" % (glyphName, ", ".join(glyphFeatures[glyphName]))
+				reportText += "\n"
+			reportText += classReportText
+			reportText += prefixFeatureReportText
 
 			self.w.result.set(reportText)
 


### PR DESCRIPTION
## Summary

- When the search term contains `*` or `?`, prepend a **GLYPH OVERVIEW** section to the report
- Lists all matched glyph names alphabetically, each followed by the feature tags it appears in (comma-separated)
- Non-wildcard searches are unchanged

Example output for `*Matra*`:
```
GLYPH OVERVIEW
iMatra-deva.001: pres, blwf, half
iMatra-deva.002: pres, blwf
iMatra-deva.003: pres

OT Classes:
	...
OT Prefixes:
	...
OT Features:
	...
```

## Test plan

- [ ] Wildcard search (e.g. `*Matra*`) shows GLYPH OVERVIEW before the other sections
- [ ] Glyph names are sorted alphabetically
- [ ] Feature tags are comma-separated and in order of appearance
- [ ] Exact-name search (no wildcards) shows no GLYPH OVERVIEW
- [ ] If no glyphs match in any feature, GLYPH OVERVIEW is omitted

https://claude.ai/code/session_01Kgj8fXMaM1yzrVUDPdAVS8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgj8fXMaM1yzrVUDPdAVS8)_