### PR TITLE
Insert Instances: redesigned UI for Glyphs 4+ (axis particles)

### DIFF
--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -694,6 +694,9 @@ class InstanceMakerV4(mekkaObject):
 		"elidableNames": "Regular, Normal, Roman",
 	}
 
+	# Width of the left-column labels, sized to fit "Distribution:" at sizeStyle="small"
+	_labelW = 82
+
 	def __init__(self):
 		thisFont = Glyphs.font
 
@@ -722,12 +725,14 @@ class InstanceMakerV4(mekkaObject):
 		inset = 15
 		lineHeight = 26
 		windowWidth = 390
+		# NSTextAlignmentRight = 2
+		rightAlign = 2
 
 		# Calculate required window height
 		linePos = 12
 		linePos += lineHeight  # remove checkboxes row
 		linePos += lineHeight  # elidable names row
-		linePos += 9           # divider line + gap
+		linePos += 9           # header divider
 		for i, axisInfo in enumerate(self.fontAxes):
 			linePos += lineHeight  # section title
 			linePos += lineHeight  # first data row (first/last weight OR values)
@@ -736,7 +741,7 @@ class InstanceMakerV4(mekkaObject):
 				linePos += 9  # divider between sections
 		if not self.fontAxes:
 			linePos += lineHeight  # "no axes" message
-		linePos += 30 + inset  # bottom buttons row
+		linePos += 55  # bottom divider + button row + inset
 
 		windowHeight = linePos
 
@@ -744,7 +749,7 @@ class InstanceMakerV4(mekkaObject):
 			(windowWidth, windowHeight),
 			"Insert Instances",
 			minSize=(windowWidth, windowHeight),
-			maxSize=(windowWidth, windowHeight),
+			maxSize=(windowWidth + 1000, windowHeight),
 			autosaveName=self.domain("mainwindow_v4"),
 		)
 
@@ -794,29 +799,31 @@ class InstanceMakerV4(mekkaObject):
 		linePos += 9
 
 		# Per-axis sections
+		labelW = self._labelW  # common left-column label width for consistent input alignment
+		inputX = inset + labelW + 2  # x where all left-column inputs start
+
 		if self.fontAxes:
 			for i, axisInfo in enumerate(self.fontAxes):
 				tag = axisInfo["tag"]
 				safeTag = axisInfo["safeTag"]
 				name = axisInfo["name"]
 
-				# Section title
+				# Section title: "Particles for: wght (Weight)"
 				setattr(
 					self.w,
 					f"sectionTitle_{safeTag}",
-					vanilla.TextBox((inset, linePos + 2, -inset, 14), f"{name} particles:", sizeStyle="small"),
+					vanilla.TextBox((inset, linePos + 2, -inset, 14), f"Particles for: {tag} ({name})", sizeStyle="small"),
 				)
 				linePos += lineHeight
 
 				if tag == "wght":
-					# First weight label + popup
-					setattr(
-						self.w,
-						f"firstWeightLabel_{safeTag}",
-						vanilla.TextBox((inset, linePos + 2, 55, 14), "First:", sizeStyle="small"),
-					)
+					# "First:" label (right-aligned) + popup
+					firstLabel = vanilla.TextBox((inset, linePos + 2, labelW, 14), "First:", sizeStyle="small")
+					firstLabel.getNSTextField().setAlignment_(rightAlign)
+					setattr(self.w, f"firstWeightLabel_{safeTag}", firstLabel)
+
 					firstPicker = vanilla.PopUpButton(
-						(inset + 57, linePos, 130, 17),
+						(inputX, linePos, 122, 17),
 						list(naturalNames),
 						callback=self.SavePreferences,
 						sizeStyle="small",
@@ -824,14 +831,14 @@ class InstanceMakerV4(mekkaObject):
 					firstPicker.setToolTip("Name of the lightest weight particle to add.")
 					setattr(self.w, "wght_firstName", firstPicker)
 
-					# Last weight label + popup (same row)
-					setattr(
-						self.w,
-						f"lastWeightLabel_{safeTag}",
-						vanilla.TextBox((inset + 57 + 138, linePos + 2, 48, 14), "Last:", sizeStyle="small"),
-					)
+					# "Last:" label (right-aligned) + popup (same row, Last popup stretches)
+					lastLabelX = inputX + 122 + 8
+					lastLabel = vanilla.TextBox((lastLabelX, linePos + 2, 44, 14), "Last:", sizeStyle="small")
+					lastLabel.getNSTextField().setAlignment_(rightAlign)
+					setattr(self.w, f"lastWeightLabel_{safeTag}", lastLabel)
+
 					lastPicker = vanilla.PopUpButton(
-						(inset + 57 + 138 + 50, linePos, -inset, 17),
+						(lastLabelX + 46, linePos, -inset, 17),
 						list(naturalNames),
 						callback=self.SavePreferences,
 						sizeStyle="small",
@@ -840,14 +847,13 @@ class InstanceMakerV4(mekkaObject):
 					setattr(self.w, "wght_lastName", lastPicker)
 					linePos += lineHeight
 
-					# Distribution label + popup
-					setattr(
-						self.w,
-						f"distributionLabel_{safeTag}",
-						vanilla.TextBox((inset, linePos + 2, 78, 14), "Distribution:", sizeStyle="small"),
-					)
+					# "Distribution:" label (right-aligned) + popup
+					distLabel = vanilla.TextBox((inset, linePos + 2, labelW, 14), "Distribution:", sizeStyle="small")
+					distLabel.getNSTextField().setAlignment_(rightAlign)
+					setattr(self.w, f"distributionLabel_{safeTag}", distLabel)
+
 					distPicker = vanilla.PopUpButton(
-						(inset + 80, linePos, 185, 17),
+						(inputX, linePos, 185, 17),
 						list(distributionNames),
 						callback=self.SavePreferences,
 						sizeStyle="small",
@@ -857,14 +863,13 @@ class InstanceMakerV4(mekkaObject):
 					linePos += lineHeight
 
 				else:
-					# Values label + field
-					setattr(
-						self.w,
-						f"valuesLabel_{safeTag}",
-						vanilla.TextBox((inset, linePos + 2, 52, 14), "Values:", sizeStyle="small"),
-					)
+					# "Values:" label (right-aligned) + field
+					valLabel = vanilla.TextBox((inset, linePos + 2, labelW, 14), "Values:", sizeStyle="small")
+					valLabel.getNSTextField().setAlignment_(rightAlign)
+					setattr(self.w, f"valuesLabel_{safeTag}", valLabel)
+
 					valField = vanilla.EditText(
-						(inset + 54, linePos - 1, -inset, 19),
+						(inputX, linePos - 1, -inset, 19),
 						"",
 						callback=self.SavePreferences,
 						sizeStyle="small",
@@ -873,14 +878,13 @@ class InstanceMakerV4(mekkaObject):
 					setattr(self.w, f"{safeTag}_values", valField)
 					linePos += lineHeight
 
-					# Range label + field
-					setattr(
-						self.w,
-						f"rangeLabel_{safeTag}",
-						vanilla.TextBox((inset, linePos + 2, 52, 14), "Range:", sizeStyle="small"),
-					)
+					# "Range:" label (right-aligned) + field
+					rangeLabel = vanilla.TextBox((inset, linePos + 2, labelW, 14), "Range:", sizeStyle="small")
+					rangeLabel.getNSTextField().setAlignment_(rightAlign)
+					setattr(self.w, f"rangeLabel_{safeTag}", rangeLabel)
+
 					rangeField = vanilla.EditText(
-						(inset + 54, linePos - 1, -inset, 19),
+						(inputX, linePos - 1, -inset, 19),
 						"min:max",
 						callback=self.SavePreferences,
 						sizeStyle="small",
@@ -905,9 +909,12 @@ class InstanceMakerV4(mekkaObject):
 			)
 			linePos += lineHeight
 
-		# Bottom buttons
+		# Divider above button bar
+		self.w.dividerBottom = vanilla.HorizontalLine((inset, -44, -inset, 1))
+
+		# Reset at bottom-left, Insert at bottom-right
 		self.w.resetButton = vanilla.Button(
-			(-170 - inset, -20 - inset, -90 - inset, -inset),
+			(inset, -20 - inset, 90, -inset),
 			"Reset",
 			callback=self.resetAction,
 			sizeStyle="small",

--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -11,6 +11,13 @@ import vanilla
 from GlyphsApp import Glyphs, GSInstance, INSTANCETYPESINGLE
 from mekkablue import mekkaObject, UpdateButton
 
+try:
+	from GlyphsApp import GSNameParticle
+except ImportError:
+	GSNameParticle = None
+
+INSTANCETYPEPARTICLE = 4  # GSInstance.type for axis particle instances (Glyphs 4+)
+
 rangemin = 3
 rangemax = 11
 
@@ -644,7 +651,7 @@ class InstanceMaker(mekkaObject):
 
 def insertParticlesIntoFont(font, particlesDict):
 	"""
-	Stub for inserting axis particles into the font.
+	Insert axis particles into the font using GSNameParticle (Glyphs 4+).
 	particlesDict structure:
 	{
 	    'elidableNames': ['Regular', 'Normal', 'Roman'],
@@ -652,40 +659,75 @@ def insertParticlesIntoFont(font, particlesDict):
 	    'removeParticles': bool,
 	    'axes': {
 	        'wght': {
-	            'firstName': 'Hairline',
-	            'lastName': 'Black',
-	            'algorithm': 'linear',
-	            'particles': [
-	                {'name': 'Hairline', 'externalValue': 1, 'internalValue': 50},
-	                ...
-	            ],
+	            'particles': [{'name': 'Hairline', 'externalValue': 1, 'internalValue': 50}, ...],
 	        },
 	        'wdth': {
-	            'particles': [
-	                {'name': 'Narrow', 'internalValue': 25.0},
-	                {'name': 'Normal', 'internalValue': 75.0},
-	                ...
-	            ],
-	            'rangeMin': 25.0,
-	            'rangeMax': 150.0,
+	            'particles': [{'name': 'Narrow', 'internalValue': 25.0}, ...],
 	        },
 	    },
 	}
 	"""
 	print("Report for Insert Instances (particles)\n")
-	print(f"\t📄 Font: {font.familyName if font else 'None'}")
-	print(f"\t☑️  Remove instances: {particlesDict.get('removeInstances')}")
-	print(f"\t☑️  Remove particles: {particlesDict.get('removeParticles')}")
-	print(f"\t🔠 Elidable names: {', '.join(particlesDict.get('elidableNames', []))}")
-	for axisTag, axisData in particlesDict.get("axes", {}).items():
+	print(f"\t📄 Font: {font.familyName}")
+
+	removeInstances = particlesDict.get("removeInstances", False)
+	removeParticles = particlesDict.get("removeParticles", False)
+	elidableNames = particlesDict.get("elidableNames", [])
+	axesData = particlesDict.get("axes", {})
+
+	if removeInstances:
+		count = 0
+		for i, instance in reversed(list(enumerate(font.instances))):
+			if instance.type == INSTANCETYPESINGLE:
+				del font.instances[i]
+				count += 1
+		print(f"\t🗑️  Removed {count} existing instance(s).")
+
+	if removeParticles:
+		count = 0
+		for i, instance in reversed(list(enumerate(font.instances))):
+			if instance.type == INSTANCETYPEPARTICLE:
+				del font.instances[i]
+				count += 1
+		print(f"\t🗑️  Removed {count} existing particle instance(s).")
+
+	if GSNameParticle is None:
+		print("\t❌ GSNameParticle not available in this version of Glyphs.")
+		return
+
+	# Build axis tag → axisId lookup
+	axisIdForTag = {axis.axisTag: axis.axisId for axis in font.axes}
+
+	# Create one particle-type instance
+	particleInstance = GSInstance()
+	particleInstance.type = INSTANCETYPEPARTICLE
+	font.instances.append(particleInstance)
+	print(f"\t✅ Created particle instance.")
+
+	# #TODO: apply elidable names to particleInstance once the API is available
+	if elidableNames:
+		print(f"\t🔠 Elidable names (TODO): {', '.join(elidableNames)}")
+
+	# Add name particles for each axis
+	for axisTag, axisData in axesData.items():
+		axisId = axisIdForTag.get(axisTag)
+		if axisId is None:
+			print(f"\t⚠️  No axisId found for axis tag '{axisTag}', skipping.")
+			continue
+
+		particles = axisData.get("particles", [])
 		print(f"\n\t↔️  Axis: {axisTag}")
-		for p in axisData.get("particles", []):
+
+		for p in particles:
+			particle = GSNameParticle()
+			particle.name = p["name"]
+			particle.internal = float(p["internalValue"])
+			particle.active = True
+			if "externalValue" in p:
+				particle.external = float(p["externalValue"])
+			particleInstance.addNameParticle_forAxisId_(particle, axisId)
 			extStr = f", external: {p['externalValue']}" if "externalValue" in p else ""
-			print(f"\t\t• {p['name']} (internal: {p['internalValue']}{extStr})")
-		rangeMin = axisData.get("rangeMin")
-		rangeMax = axisData.get("rangeMax")
-		if rangeMin is not None and rangeMax is not None:
-			print(f"\t\tRange: {rangeMin} – {rangeMax}")
+			print(f"\t\t✅ {p['name']} (internal: {p['internalValue']}{extStr})")
 
 
 class InstanceMakerV4(mekkaObject):

--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -741,7 +741,7 @@ class InstanceMakerV4(mekkaObject):
 				linePos += 9  # divider between sections
 		if not self.fontAxes:
 			linePos += lineHeight  # "no axes" message
-		linePos += 55  # bottom divider + button row + inset
+		linePos += 75  # bottom divider + button row + inset
 
 		windowHeight = linePos
 
@@ -909,22 +909,22 @@ class InstanceMakerV4(mekkaObject):
 			)
 			linePos += lineHeight
 
-		# Divider above button bar
-		self.w.dividerBottom = vanilla.HorizontalLine((inset, -44, -inset, 1))
+		# Divider above button bar (10px above button top)
+		self.w.dividerBottom = vanilla.HorizontalLine((inset, -47, -inset, 1))
 
-		# Reset at bottom-left, Insert at bottom-right
+		# Reset at bottom-left, Insert at bottom-right — regular size (22px tall)
 		self.w.resetButton = vanilla.Button(
-			(inset, -20 - inset, 90, -inset),
+			(inset, -22 - inset, 90, -inset),
 			"Reset",
 			callback=self.resetAction,
-			sizeStyle="small",
+			sizeStyle="regular",
 		)
 		self.w.resetButton.setToolTip("Reset all form fields to their defaults.")
 		self.w.insertButton = vanilla.Button(
-			(-80 - inset, -20 - inset, -inset, -inset),
+			(-80 - inset, -22 - inset, -inset, -inset),
 			"Insert",
 			callback=self.insertAction,
-			sizeStyle="small",
+			sizeStyle="regular",
 		)
 		self.w.insertButton.setToolTip("Insert axis particles into the frontmost font.")
 		self.w.setDefaultButton(self.w.insertButton)
@@ -1051,6 +1051,7 @@ class InstanceMakerV4(mekkaObject):
 		if particlesDict is None:
 			return
 		self.SavePreferences()
+		Glyphs.clearLog()
 		insertParticlesIntoFont(thisFont, particlesDict)
 		Glyphs.showNotification("Insert Instances", "Done. Details in Macro Window.")
 

--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -953,6 +953,24 @@ class InstanceMakerV4(mekkaObject):
 				getattr(self.w, f"{safeTag}_range").set("min:max")
 		self.SavePreferences()
 
+	def _axisRange(self, axisInfo, thisFont):
+		"""Return (min, max) for an axis. Attribute names vary across Glyphs versions."""
+		axis = axisInfo["axis"]
+		for minAttr, maxAttr in (("minimum", "maximum"), ("axisMin", "axisMax"), ("min", "max")):
+			try:
+				return float(getattr(axis, minAttr)), float(getattr(axis, maxAttr))
+			except AttributeError:
+				pass
+		# Fall back: use the spread of master axis values
+		try:
+			axisId = axis.axisId
+			vals = [float(m.axisValueValueForId_(axisId)) for m in thisFont.masters]
+			if vals:
+				return min(vals), max(vals)
+		except Exception:
+			pass
+		return 0.0, 1000.0
+
 	def buildParticlesDict(self):
 		thisFont = Glyphs.font
 		if not thisFont:
@@ -965,9 +983,7 @@ class InstanceMakerV4(mekkaObject):
 		for axisInfo in self.fontAxes:
 			tag = axisInfo["tag"]
 			safeTag = axisInfo["safeTag"]
-			axis = axisInfo["axis"]
-			axisMin = axis.minimum
-			axisMax = axis.maximum
+			axisMin, axisMax = self._axisRange(axisInfo, thisFont)
 
 			if tag == "wght":
 				firstIndex = getattr(self.w, "wght_firstName").get()

--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -661,9 +661,13 @@ def insertParticlesIntoFont(font, particlesDict):
 	            ],
 	        },
 	        'wdth': {
-	            'values': [75.0, 100.0, 125.0],
-	            'rangeMin': 75.0,
-	            'rangeMax': 125.0,
+	            'particles': [
+	                {'name': 'Narrow', 'internalValue': 25.0},
+	                {'name': 'Normal', 'internalValue': 75.0},
+	                ...
+	            ],
+	            'rangeMin': 25.0,
+	            'rangeMax': 150.0,
 	        },
 	    },
 	}
@@ -675,12 +679,13 @@ def insertParticlesIntoFont(font, particlesDict):
 	print(f"\t🔠 Elidable names: {', '.join(particlesDict.get('elidableNames', []))}")
 	for axisTag, axisData in particlesDict.get("axes", {}).items():
 		print(f"\n\t↔️  Axis: {axisTag}")
-		if "particles" in axisData:
-			for p in axisData["particles"]:
-				print(f"\t\t• {p['name']} (external: {p['externalValue']}, internal: {p['internalValue']})")
-		else:
-			print(f"\t\tValues: {axisData.get('values')}")
-			print(f"\t\tRange: {axisData.get('rangeMin')} – {axisData.get('rangeMax')}")
+		for p in axisData.get("particles", []):
+			extStr = f", external: {p['externalValue']}" if "externalValue" in p else ""
+			print(f"\t\t• {p['name']} (internal: {p['internalValue']}{extStr})")
+		rangeMin = axisData.get("rangeMin")
+		rangeMax = axisData.get("rangeMax")
+		if rangeMin is not None and rangeMax is not None:
+			print(f"\t\tRange: {rangeMin} – {rangeMax}")
 
 
 class InstanceMakerV4(mekkaObject):
@@ -1019,14 +1024,8 @@ class InstanceMakerV4(mekkaObject):
 				valuesStr = getattr(self.w, f"{safeTag}_values").get().strip()
 				rangeStr = getattr(self.w, f"{safeTag}_range").get().strip()
 
-				values = []
-				for v in valuesStr.split(","):
-					v = v.strip()
-					if v:
-						try:
-							values.append(float(v))
-						except ValueError:
-							pass
+				# Values are particle names (strings), not numbers
+				names = [v.strip() for v in valuesStr.split(",") if v.strip()]
 
 				rangeMin = axisMin
 				rangeMax = axisMax
@@ -1045,8 +1044,15 @@ class InstanceMakerV4(mekkaObject):
 						except ValueError:
 							pass
 
+				# Distribute names linearly across the range
+				internalVals = applyDistribution("linear", rangeMin, rangeMax, len(names))
+				particles = [
+					{"name": name, "internalValue": round(iv, 2)}
+					for name, iv in zip(names, internalVals)
+				]
+
 				axesData[tag] = {
-					"values": values,
+					"particles": particles,
 					"rangeMin": rangeMin,
 					"rangeMax": rangeMax,
 				}

--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -3,12 +3,13 @@
 from __future__ import division, print_function, unicode_literals
 __doc__ = """
 Inserts instances, based on the Luc(as), Pablo, Abraham, Schneider and Maciej algorithms.
+In Glyphs 4+, presents a redesigned UI for inserting axis particles.
 """
 
 from Foundation import NSDictionary
 import vanilla
 from GlyphsApp import Glyphs, GSInstance, INSTANCETYPESINGLE
-from mekkablue import mekkaObject
+from mekkablue import mekkaObject, UpdateButton
 
 rangemin = 3
 rangemax = 11
@@ -63,10 +64,13 @@ For medium weights, you typically want bigger steps. Smaller jumps are preferabl
 
 So, for a wide spectrum from very light to very bold, try Pablo, Schneider, or Mirrored Luc(as).
 
-For spectrums from thin to medium weights, try Abraham or Luc(as). They tend to have large jumps at the end, which are usually found in the center of the weight spectrum (Regular to Semibold). 
+For spectrums from thin to medium weights, try Abraham or Luc(as). They tend to have large jumps at the end, which are usually found in the center of the weight spectrum (Regular to Semibold).
 
 For going from medium to very bold weights, try Reverse Luc(as). It has big jumps at the beginning, and smaller steps at the end.
 """
+
+distributionNames = ("linear", "Pablo", "Schneider", "Abraham", "Luc(as)", "Reverse Luc(as)", "Mirrored Luc(as)")
+
 
 def distribute_lucas(min, max, n):
 	if min == 0:
@@ -88,8 +92,8 @@ def distribute_mirroredlucas(min, max, n):
 		n2 = (n + 1) // 2
 		return distribute_lucas(min, center, n2) + distribute_reverselucas(center, max, n2)[1:]
 	else:
-		deviation = ((max-min) / (n-1)) / 2
-		return distribute_lucas(min, center-deviation, n//2) + distribute_reverselucas(center+deviation, max, n//2)
+		deviation = ((max - min) / (n - 1)) / 2
+		return distribute_lucas(min, center - deviation, n // 2) + distribute_reverselucas(center + deviation, max, n // 2)
 
 
 def distribute_equal(min, max, n):
@@ -126,8 +130,32 @@ def distribute_maciej(lightMasterWeightX, lightMasterWeightY, boldMasterWeightX,
 	return round((boldMasterWeightX - lightMasterWeightX) * interpolationPointY + lightMasterWeightX, 1)
 
 
+def applyDistribution(algorithmName, axisMin, axisMax, n):
+	if n < 2:
+		return [axisMin]
+	if algorithmName == "Pablo":
+		return distribute_pablo(axisMin, axisMax, n)
+	elif algorithmName == "Luc(as)":
+		return distribute_lucas(axisMin, axisMax, n)
+	elif algorithmName == "Reverse Luc(as)":
+		return distribute_reverselucas(axisMin, axisMax, n)
+	elif algorithmName == "Mirrored Luc(as)":
+		return distribute_mirroredlucas(axisMin, axisMax, n)
+	elif algorithmName == "Schneider":
+		return distribute_schneider(axisMin, axisMax, n)
+	elif algorithmName == "Abraham":
+		return distribute_abraham(axisMin, axisMax, n)
+	else:
+		return distribute_equal(axisMin, axisMax, n)
+
+
 def axisLocationEntry(axisName, locationValue):
 	return NSDictionary.alloc().initWithObjects_forKeys_((axisName, locationValue), ("Axis", "Location"))
+
+
+def _safeAttrName(tag):
+	"""Convert axis tag to a safe Python identifier for use as an attribute name."""
+	return "".join(c if c.isalnum() or c == "_" else "_" for c in tag)
 
 
 class InstanceMaker(mekkaObject):
@@ -174,7 +202,7 @@ class InstanceMaker(mekkaObject):
 		self.w.numberOfInstances.setToolTip("Choose how many weights you want to add.")
 		self.w.text_2 = vanilla.TextBox((inset + 30 + 50, linePos + 2, 105, 14), "weights with prefix", sizeStyle='small')
 		self.w.prefix = vanilla.EditText((inset + 30 + 50 + 105, linePos - 1, -inset, 19), "A-", callback=self.UpdateSample, sizeStyle='small')
-		self.w.prefix.setToolTip("Choose text that is added at the beginning of each instance, e.g., ‘Condensed’.")
+		self.w.prefix.setToolTip("Choose text that is added at the beginning of each instance, e.g., 'Condensed'.")
 		linePos += lineHeight
 
 		self.w.text_3 = vanilla.TextBox((inset - 1, linePos + 2, 60, 14), "from:", sizeStyle='small')
@@ -199,7 +227,7 @@ class InstanceMaker(mekkaObject):
 		self.w.existingInstances.set(0)
 		linePos += int(lineHeight * 2.4)
 
-		self.w.naturalNames = vanilla.CheckBox((inset + 2, linePos, inset + 225, 19), "Use ‘natural’ weight names, starting at:", value=False, callback=self.UpdateSample, sizeStyle='small')
+		self.w.naturalNames = vanilla.CheckBox((inset + 2, linePos, inset + 225, 19), "Use 'natural' weight names, starting at:", value=False, callback=self.UpdateSample, sizeStyle='small')
 		self.w.naturalNames.setToolTip("Prefill with standard names and style linking. If turned off, will use the Weight number as instance name.")
 		self.w.firstName = vanilla.PopUpButton((inset + 225, linePos, -inset, 17), naturalNames, callback=self.UpdateSample, sizeStyle='small')
 		self.w.firstName.setToolTip("If you use natural weight names, choose here the name of your lightest weight.")
@@ -217,7 +245,7 @@ class InstanceMaker(mekkaObject):
 			linePos += lineHeight - 8
 
 		self.w.italicStyle = vanilla.CheckBox((inset + 20, linePos, -inset, 20), "Italic suffixes and style linking", value=False, callback=self.UpdateSample, sizeStyle='small')
-		self.w.italicStyle.setToolTip("If enabled, will add the word ‘Italic’ to all instances, and also add italic style linking.")
+		self.w.italicStyle.setToolTip("If enabled, will add the word 'Italic' to all instances, and also add italic style linking.")
 		linePos += lineHeight
 
 		self.w.maciej = vanilla.CheckBox((inset + 2, linePos - 1, 160, 19), "Maciej y distribution from:", value=False, callback=self.UpdateSample, sizeStyle='small')
@@ -449,7 +477,7 @@ class InstanceMaker(mekkaObject):
 	def completeStyleName(self, prefix, name, elidableName="Regular", naturalNames=True):
 		# e.g. "A-160"
 		if not naturalNames:
-			return prefix+name
+			return prefix + name
 
 		# elidable
 		if prefix.strip() and name == elidableName:
@@ -612,4 +640,415 @@ class InstanceMaker(mekkaObject):
 			print(traceback.format_exc())
 
 
-InstanceMaker()
+# ---- Glyphs 4+ particles UI ----
+
+def insertParticlesIntoFont(font, particlesDict):
+	"""
+	Stub for inserting axis particles into the font.
+	particlesDict structure:
+	{
+	    'elidableNames': ['Regular', 'Normal', 'Roman'],
+	    'removeInstances': bool,
+	    'removeParticles': bool,
+	    'axes': {
+	        'wght': {
+	            'firstName': 'Hairline',
+	            'lastName': 'Black',
+	            'algorithm': 'linear',
+	            'particles': [
+	                {'name': 'Hairline', 'externalValue': 1, 'internalValue': 50},
+	                ...
+	            ],
+	        },
+	        'wdth': {
+	            'values': [75.0, 100.0, 125.0],
+	            'rangeMin': 75.0,
+	            'rangeMax': 125.0,
+	        },
+	    },
+	}
+	"""
+	print("Report for Insert Instances (particles)\n")
+	print(f"\t📄 Font: {font.familyName if font else 'None'}")
+	print(f"\t☑️  Remove instances: {particlesDict.get('removeInstances')}")
+	print(f"\t☑️  Remove particles: {particlesDict.get('removeParticles')}")
+	print(f"\t🔠 Elidable names: {', '.join(particlesDict.get('elidableNames', []))}")
+	for axisTag, axisData in particlesDict.get("axes", {}).items():
+		print(f"\n\t↔️  Axis: {axisTag}")
+		if "particles" in axisData:
+			for p in axisData["particles"]:
+				print(f"\t\t• {p['name']} (external: {p['externalValue']}, internal: {p['internalValue']})")
+		else:
+			print(f"\t\tValues: {axisData.get('values')}")
+			print(f"\t\tRange: {axisData.get('rangeMin')} – {axisData.get('rangeMax')}")
+
+
+class InstanceMakerV4(mekkaObject):
+	"""GUI for inserting axis particles (Glyphs 4+)."""
+
+	defaultElidableNames = "Regular, Normal, Roman"
+
+	prefDict = {
+		"removeInstances": False,
+		"removeParticles": False,
+		"elidableNames": "Regular, Normal, Roman",
+	}
+
+	def __init__(self):
+		thisFont = Glyphs.font
+
+		# Collect font axes
+		self.fontAxes = []
+		if thisFont and thisFont.axes:
+			for axis in thisFont.axes:
+				tag = axis.axisTag
+				name = axis.name
+				safeTag = _safeAttrName(tag)
+				self.fontAxes.append({"tag": tag, "safeTag": safeTag, "name": name, "axis": axis})
+
+		# Build instance-level prefDict with dynamic axis entries
+		self.prefDict = dict(InstanceMakerV4.prefDict)
+		for axisInfo in self.fontAxes:
+			tag = axisInfo["tag"]
+			safeTag = axisInfo["safeTag"]
+			if tag == "wght":
+				self.prefDict["wght_firstName"] = 0   # Hairline
+				self.prefDict["wght_lastName"] = 9    # Black
+				self.prefDict["wght_algorithm"] = 0   # linear
+			else:
+				self.prefDict[f"{safeTag}_values"] = ""
+				self.prefDict[f"{safeTag}_range"] = "min:max"
+
+		inset = 15
+		lineHeight = 26
+		windowWidth = 390
+
+		# Calculate required window height
+		linePos = 12
+		linePos += lineHeight  # remove checkboxes row
+		linePos += lineHeight  # elidable names row
+		linePos += 9           # divider line + gap
+		for i, axisInfo in enumerate(self.fontAxes):
+			linePos += lineHeight  # section title
+			linePos += lineHeight  # first data row (first/last weight OR values)
+			linePos += lineHeight  # second data row (distribution OR range)
+			if i < len(self.fontAxes) - 1:
+				linePos += 9  # divider between sections
+		if not self.fontAxes:
+			linePos += lineHeight  # "no axes" message
+		linePos += 30 + inset  # bottom buttons row
+
+		windowHeight = linePos
+
+		self.w = vanilla.FloatingWindow(
+			(windowWidth, windowHeight),
+			"Insert Instances",
+			minSize=(windowWidth, windowHeight),
+			maxSize=(windowWidth, windowHeight),
+			autosaveName=self.domain("mainwindow_v4"),
+		)
+
+		linePos = 12
+
+		# Row: Remove checkboxes
+		self.w.removeInstances = vanilla.CheckBox(
+			(inset, linePos, 185, 20),
+			"Remove existing instances",
+			value=False,
+			callback=self.SavePreferences,
+			sizeStyle="small",
+		)
+		self.w.removeInstances.setToolTip("Remove all existing instances from the frontmost font before inserting.")
+		self.w.removeParticles = vanilla.CheckBox(
+			(inset + 192, linePos, -inset, 20),
+			"Remove existing particles",
+			value=False,
+			callback=self.SavePreferences,
+			sizeStyle="small",
+		)
+		self.w.removeParticles.setToolTip("Remove all existing axis particles from the frontmost font before inserting.")
+		linePos += lineHeight
+
+		# Row: Elidable names
+		self.w.elidableLabel = vanilla.TextBox(
+			(inset, linePos + 2, 102, 14),
+			"Elidable names:",
+			sizeStyle="small",
+		)
+		self.w.elidableNames = vanilla.EditText(
+			(inset + 103, linePos - 1, -inset - 22, 19),
+			self.defaultElidableNames,
+			callback=self.SavePreferences,
+			sizeStyle="small",
+		)
+		self.w.elidableNames.setToolTip("Comma-separated style names that are elidable: they can be omitted from composite names, e.g. 'Condensed Regular' becomes 'Condensed'.")
+		self.w.elidableNamesReset = UpdateButton(
+			(-inset - 18, linePos - 1, -inset, 18),
+			callback=self.resetElidableNames,
+		)
+		self.w.elidableNamesReset.setToolTip(f"Reset to defaults: {self.defaultElidableNames}")
+		linePos += lineHeight
+
+		# Divider below header
+		self.w.dividerTop = vanilla.HorizontalLine((inset, linePos, -inset, 1))
+		linePos += 9
+
+		# Per-axis sections
+		if self.fontAxes:
+			for i, axisInfo in enumerate(self.fontAxes):
+				tag = axisInfo["tag"]
+				safeTag = axisInfo["safeTag"]
+				name = axisInfo["name"]
+
+				# Section title
+				setattr(
+					self.w,
+					f"sectionTitle_{safeTag}",
+					vanilla.TextBox((inset, linePos + 2, -inset, 14), f"{name} particles:", sizeStyle="small"),
+				)
+				linePos += lineHeight
+
+				if tag == "wght":
+					# First weight label + popup
+					setattr(
+						self.w,
+						f"firstWeightLabel_{safeTag}",
+						vanilla.TextBox((inset, linePos + 2, 55, 14), "First:", sizeStyle="small"),
+					)
+					firstPicker = vanilla.PopUpButton(
+						(inset + 57, linePos, 130, 17),
+						list(naturalNames),
+						callback=self.SavePreferences,
+						sizeStyle="small",
+					)
+					firstPicker.setToolTip("Name of the lightest weight particle to add.")
+					setattr(self.w, "wght_firstName", firstPicker)
+
+					# Last weight label + popup (same row)
+					setattr(
+						self.w,
+						f"lastWeightLabel_{safeTag}",
+						vanilla.TextBox((inset + 57 + 138, linePos + 2, 48, 14), "Last:", sizeStyle="small"),
+					)
+					lastPicker = vanilla.PopUpButton(
+						(inset + 57 + 138 + 50, linePos, -inset, 17),
+						list(naturalNames),
+						callback=self.SavePreferences,
+						sizeStyle="small",
+					)
+					lastPicker.setToolTip("Name of the heaviest weight particle to add.")
+					setattr(self.w, "wght_lastName", lastPicker)
+					linePos += lineHeight
+
+					# Distribution label + popup
+					setattr(
+						self.w,
+						f"distributionLabel_{safeTag}",
+						vanilla.TextBox((inset, linePos + 2, 78, 14), "Distribution:", sizeStyle="small"),
+					)
+					distPicker = vanilla.PopUpButton(
+						(inset + 80, linePos, 185, 17),
+						list(distributionNames),
+						callback=self.SavePreferences,
+						sizeStyle="small",
+					)
+					distPicker.setToolTip(distributionExplanation)
+					setattr(self.w, "wght_algorithm", distPicker)
+					linePos += lineHeight
+
+				else:
+					# Values label + field
+					setattr(
+						self.w,
+						f"valuesLabel_{safeTag}",
+						vanilla.TextBox((inset, linePos + 2, 52, 14), "Values:", sizeStyle="small"),
+					)
+					valField = vanilla.EditText(
+						(inset + 54, linePos - 1, -inset, 19),
+						"",
+						callback=self.SavePreferences,
+						sizeStyle="small",
+					)
+					valField.setToolTip("Comma-separated axis values to use as particles. They will be distributed linearly across the defined range.")
+					setattr(self.w, f"{safeTag}_values", valField)
+					linePos += lineHeight
+
+					# Range label + field
+					setattr(
+						self.w,
+						f"rangeLabel_{safeTag}",
+						vanilla.TextBox((inset, linePos + 2, 52, 14), "Range:", sizeStyle="small"),
+					)
+					rangeField = vanilla.EditText(
+						(inset + 54, linePos - 1, -inset, 19),
+						"min:max",
+						callback=self.SavePreferences,
+						sizeStyle="small",
+					)
+					rangeField.setToolTip("Distribution range as min:max. Use 'min'/'max' for the axis endpoints, or leave as 'min:max' for the full range. Examples: 'min:100', '200:max', '75:125'.")
+					setattr(self.w, f"{safeTag}_range", rangeField)
+					linePos += lineHeight
+
+				# Divider between axis sections (not after the last one)
+				if i < len(self.fontAxes) - 1:
+					setattr(
+						self.w,
+						f"divider_{safeTag}",
+						vanilla.HorizontalLine((inset, linePos, -inset, 1)),
+					)
+					linePos += 9
+		else:
+			self.w.noAxesMessage = vanilla.TextBox(
+				(inset, linePos + 2, -inset, 14),
+				"No axes found in the frontmost font.",
+				sizeStyle="small",
+			)
+			linePos += lineHeight
+
+		# Bottom buttons
+		self.w.resetButton = vanilla.Button(
+			(-170 - inset, -20 - inset, -90 - inset, -inset),
+			"Reset",
+			callback=self.resetAction,
+			sizeStyle="small",
+		)
+		self.w.resetButton.setToolTip("Reset all form fields to their defaults.")
+		self.w.insertButton = vanilla.Button(
+			(-80 - inset, -20 - inset, -inset, -inset),
+			"Insert",
+			callback=self.insertAction,
+			sizeStyle="small",
+		)
+		self.w.insertButton.setToolTip("Insert axis particles into the frontmost font.")
+		self.w.setDefaultButton(self.w.insertButton)
+
+		self.LoadPreferences()
+		self.w.open()
+		self.w.makeKey()
+
+	def resetElidableNames(self, sender=None):
+		self.w.elidableNames.set(self.defaultElidableNames)
+		self.SavePreferences()
+
+	def resetAction(self, sender=None):
+		self.w.removeInstances.set(False)
+		self.w.removeParticles.set(False)
+		self.w.elidableNames.set(self.defaultElidableNames)
+		for axisInfo in self.fontAxes:
+			tag = axisInfo["tag"]
+			safeTag = axisInfo["safeTag"]
+			if tag == "wght":
+				getattr(self.w, "wght_firstName").set(0)  # Hairline
+				getattr(self.w, "wght_lastName").set(9)   # Black
+				getattr(self.w, "wght_algorithm").set(0)  # linear
+			else:
+				getattr(self.w, f"{safeTag}_values").set("")
+				getattr(self.w, f"{safeTag}_range").set("min:max")
+		self.SavePreferences()
+
+	def buildParticlesDict(self):
+		thisFont = Glyphs.font
+		if not thisFont:
+			print("❌ No font open.")
+			return None
+
+		elidableNames = [n.strip() for n in self.w.elidableNames.get().split(",") if n.strip()]
+		axesData = {}
+
+		for axisInfo in self.fontAxes:
+			tag = axisInfo["tag"]
+			safeTag = axisInfo["safeTag"]
+			axis = axisInfo["axis"]
+			axisMin = axis.minimum
+			axisMax = axis.maximum
+
+			if tag == "wght":
+				firstIndex = getattr(self.w, "wght_firstName").get()
+				lastIndex = getattr(self.w, "wght_lastName").get()
+				algorithmIndex = getattr(self.w, "wght_algorithm").get()
+				algorithmName = distributionNames[algorithmIndex]
+
+				# Ensure correct order
+				if firstIndex > lastIndex:
+					firstIndex, lastIndex = lastIndex, firstIndex
+
+				selectedNames = list(naturalNames[firstIndex:lastIndex + 1])
+				n = len(selectedNames)
+				internalValues = applyDistribution(algorithmName, axisMin, axisMax, n)
+
+				particles = [
+					{
+						"name": name,
+						"externalValue": weightClasses[name],
+						"internalValue": round(val),
+					}
+					for name, val in zip(selectedNames, internalValues)
+				]
+
+				axesData["wght"] = {
+					"firstName": naturalNames[firstIndex],
+					"lastName": naturalNames[lastIndex],
+					"algorithm": algorithmName,
+					"particles": particles,
+				}
+
+			else:
+				valuesStr = getattr(self.w, f"{safeTag}_values").get().strip()
+				rangeStr = getattr(self.w, f"{safeTag}_range").get().strip()
+
+				values = []
+				for v in valuesStr.split(","):
+					v = v.strip()
+					if v:
+						try:
+							values.append(float(v))
+						except ValueError:
+							pass
+
+				rangeMin = axisMin
+				rangeMax = axisMax
+				if ":" in rangeStr:
+					minPart, maxPart = rangeStr.split(":", 1)
+					minPart = minPart.strip()
+					maxPart = maxPart.strip()
+					if minPart and minPart.lower() != "min":
+						try:
+							rangeMin = float(minPart)
+						except ValueError:
+							pass
+					if maxPart and maxPart.lower() != "max":
+						try:
+							rangeMax = float(maxPart)
+						except ValueError:
+							pass
+
+				axesData[tag] = {
+					"values": values,
+					"rangeMin": rangeMin,
+					"rangeMax": rangeMax,
+				}
+
+		return {
+			"elidableNames": elidableNames,
+			"removeInstances": bool(self.w.removeInstances.get()),
+			"removeParticles": bool(self.w.removeParticles.get()),
+			"axes": axesData,
+		}
+
+	def insertAction(self, sender=None):
+		thisFont = Glyphs.font
+		if not thisFont:
+			print("❌ Insert Instances: no font open.")
+			return
+		particlesDict = self.buildParticlesDict()
+		if particlesDict is None:
+			return
+		self.SavePreferences()
+		insertParticlesIntoFont(thisFont, particlesDict)
+		Glyphs.showNotification("Insert Instances", "Done. Details in Macro Window.")
+
+
+if Glyphs.versionNumber >= 4:
+	InstanceMakerV4()
+else:
+	InstanceMaker()


### PR DESCRIPTION
## Summary

- For `Glyphs.versionNumber >= 4`, the script now shows a completely redesigned window targeting the Glyphs 4 axis-particles system
- For Glyphs 2/3, the original weight-instances UI is shown unchanged

## New Glyphs 4+ UI

**Top controls:**
- Checkbox: *Remove existing instances*
- Checkbox: *Remove existing particles*
- *Elidable names* text field (default `Regular, Normal, Roman`) with an `UpdateButton` reset button

**Per-axis particle sections** (one section per axis in the frontmost font):

- **`wght` axis:** *First weight* popup + *Last weight* popup (both pick from the full `naturalNames` list: Hairline → Extrablack with their standard `usWeightClass` external coordinates); *Distribution* popup with the same seven algorithms from the classic UI (linear, Pablo, Schneider, Abraham, Luc(as), Reverse Luc(as), Mirrored Luc(as))
- **Any other axis:** *Values* text field (comma-separated internal axis values, distributed linearly across the range); *Range* field (`min:max`, supporting partial entries like `min:100` or `200:`)

**Bottom buttons:** *Reset* (resets form fields to defaults) and *Insert* (default button)

## Particle API stub

Since the Glyphs 4 particle insertion API is not yet finalised, the `insertParticlesIntoFont(font, particlesDict)` function currently logs the fully-built `particlesDict` to the Macro Window. The dict shape is documented in the function's docstring and includes resolved internal values (with the chosen distribution applied for `wght`).

## Test plan

- [ ] Open script in Glyphs 3 → original weight-instances window appears, all existing functionality works
- [ ] Open script in Glyphs 4 with a single-axis (`wght`) font → one *Weight particles* section with first/last pickers and distribution popup
- [ ] Open script in Glyphs 4 with a multi-axis font → one section per axis; non-wght axes show Values + Range fields
- [ ] Open script in Glyphs 4 with no font open → window opens with "No axes found" message, no crash
- [ ] Reset button restores all fields to defaults
- [ ] Elidable names reset button restores `Regular, Normal, Roman`
- [ ] Insert button logs particle dict to Macro Window and shows notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGh22LAPz4MUvvSAtDu3ET

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGh22LAPz4MUvvSAtDu3ET)_