### PR TITLE
Add Bookmaker: LaTeX-based book layout editor for Mac

### DIFF
--- a/Bookmaker/.gitignore
+++ b/Bookmaker/.gitignore
@@ -1,0 +1,4 @@
+xcuserdata/
+*.xcuserstate
+DerivedData/
+.DS_Store

--- a/Bookmaker/Bookmaker.xcodeproj/project.pbxproj
+++ b/Bookmaker/Bookmaker.xcodeproj/project.pbxproj
@@ -1,0 +1,270 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AB0000010000000000000101 /* BookmakerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000000000001 /* BookmakerApp.swift */; };
+		AB0000010000000000000102 /* BookDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000000000002 /* BookDocument.swift */; };
+		AB0000010000000000000103 /* LaTeXEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000000000003 /* LaTeXEngine.swift */; };
+		AB0000010000000000000104 /* TypesetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000000000004 /* TypesetController.swift */; };
+		AB0000010000000000000105 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000000000005 /* ContentView.swift */; };
+		AB0000010000000000000106 /* PDFPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000000000006 /* PDFPreviewView.swift */; };
+		AB0000010000000000000107 /* PageSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0000010000000000000007 /* PageSetupView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		AB0000010000000000000001 /* BookmakerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmakerApp.swift; sourceTree = "<group>"; };
+		AB0000010000000000000002 /* BookDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDocument.swift; sourceTree = "<group>"; };
+		AB0000010000000000000003 /* LaTeXEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaTeXEngine.swift; sourceTree = "<group>"; };
+		AB0000010000000000000004 /* TypesetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypesetController.swift; sourceTree = "<group>"; };
+		AB0000010000000000000005 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		AB0000010000000000000006 /* PDFPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPreviewView.swift; sourceTree = "<group>"; };
+		AB0000010000000000000007 /* PageSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageSetupView.swift; sourceTree = "<group>"; };
+		AB0000010000000000000008 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AB0000010000000000000009 /* Bookmaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bookmaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AB0000010000000000000302 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AB0000010000000000000201 = {
+			isa = PBXGroup;
+			children = (
+				AB0000010000000000000202 /* Bookmaker */,
+				AB0000010000000000000203 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AB0000010000000000000202 /* Bookmaker */ = {
+			isa = PBXGroup;
+			children = (
+				AB0000010000000000000001 /* BookmakerApp.swift */,
+				AB0000010000000000000002 /* BookDocument.swift */,
+				AB0000010000000000000003 /* LaTeXEngine.swift */,
+				AB0000010000000000000004 /* TypesetController.swift */,
+				AB0000010000000000000005 /* ContentView.swift */,
+				AB0000010000000000000006 /* PDFPreviewView.swift */,
+				AB0000010000000000000007 /* PageSetupView.swift */,
+				AB0000010000000000000008 /* Info.plist */,
+			);
+			path = Bookmaker;
+			sourceTree = "<group>";
+		};
+		AB0000010000000000000203 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AB0000010000000000000009 /* Bookmaker.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AB0000010000000000000401 /* Bookmaker */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AB0000010000000000000702 /* Build configuration list for PBXNativeTarget "Bookmaker" */;
+			buildPhases = (
+				AB0000010000000000000301 /* Sources */,
+				AB0000010000000000000302 /* Frameworks */,
+				AB0000010000000000000303 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Bookmaker;
+			productName = Bookmaker;
+			productReference = AB0000010000000000000009 /* Bookmaker.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AB0000010000000000000501 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					AB0000010000000000000401 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = AB0000010000000000000701 /* Build configuration list for PBXProject "Bookmaker" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AB0000010000000000000201;
+			productRefGroup = AB0000010000000000000203 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AB0000010000000000000401 /* Bookmaker */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AB0000010000000000000303 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AB0000010000000000000301 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AB0000010000000000000101 /* BookmakerApp.swift in Sources */,
+				AB0000010000000000000102 /* BookDocument.swift in Sources */,
+				AB0000010000000000000103 /* LaTeXEngine.swift in Sources */,
+				AB0000010000000000000104 /* TypesetController.swift in Sources */,
+				AB0000010000000000000105 /* ContentView.swift in Sources */,
+				AB0000010000000000000106 /* PDFPreviewView.swift in Sources */,
+				AB0000010000000000000107 /* PageSetupView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		AB0000010000000000000601 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AB0000010000000000000602 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		AB0000010000000000000603 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Bookmaker/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mekkablue.Bookmaker;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		AB0000010000000000000604 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Bookmaker/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mekkablue.Bookmaker;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AB0000010000000000000701 /* Build configuration list for PBXProject "Bookmaker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB0000010000000000000601 /* Debug */,
+				AB0000010000000000000602 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AB0000010000000000000702 /* Build configuration list for PBXNativeTarget "Bookmaker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB0000010000000000000603 /* Debug */,
+				AB0000010000000000000604 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AB0000010000000000000501 /* Project object */;
+}

--- a/Bookmaker/Bookmaker/BookDocument.swift
+++ b/Bookmaker/Bookmaker/BookDocument.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension UTType {
+	static let bookmakerBook = UTType(exportedAs: "com.mekkablue.bookmaker.book")
+}
+
+struct PageSettings: Codable, Equatable {
+	var paperWidth: Double = 148.0
+	var paperHeight: Double = 210.0
+	var marginTop: Double = 20.0
+	var marginBottom: Double = 25.0
+	var marginInner: Double = 22.0
+	var marginOuter: Double = 18.0
+
+	var geometryOptions: String {
+		String(
+			format: "paperwidth=%.5gmm, paperheight=%.5gmm, top=%.5gmm, bottom=%.5gmm, inner=%.5gmm, outer=%.5gmm",
+			paperWidth, paperHeight, marginTop, marginBottom, marginInner, marginOuter
+		)
+	}
+}
+
+enum DefaultTemplates {
+	/// Wrapper for the whole book: document class, page geometry, running headers.
+	/// Placeholders: {{GEOMETRY}} (from page settings), {{TOC}} (TOC template), {{BODY}} (body text).
+	static let spread = #"""
+	\documentclass[11pt,twoside,openright]{book}
+	\usepackage[{{GEOMETRY}}]{geometry}
+	\usepackage{fancyhdr}
+	\setlength{\headheight}{14pt}
+	\pagestyle{fancy}
+	\fancyhf{}
+	\fancyhead[LE]{\small\itshape\leftmark}
+	\fancyhead[RO]{\small\itshape\rightmark}
+	\fancyfoot[LE,RO]{\small\thepage}
+	\renewcommand{\headrulewidth}{0pt}
+
+	\begin{document}
+
+	{{TOC}}
+
+	{{BODY}}
+
+	\end{document}
+	"""#
+
+	/// Inserted where {{TOC}} appears in the spread template.
+	static let toc = #"""
+	\frontmatter
+	\tableofcontents
+	\mainmatter
+	"""#
+
+	static let sampleBody = #"""
+	\chapter{The Shape of a Page}
+
+	Every book begins not with its first sentence but with the shape of its page. The proportions of the paper, the weight of the margins, the width of the measure: these decisions are made before a single word is set, and they quietly govern everything that follows.
+
+	\section{Margins}
+
+	Margins are not empty space. They hold the thumbs of the reader, carry the running heads and folios, and balance the text block on the spread. A book set with generous inner margins opens comfortably; one set without them drowns its text in the gutter.
+
+	Traditionally the inner margin is narrower than the outer, so that the two text blocks of a spread read as a single unit. The bottom margin is usually the largest, keeping the text block from appearing to slide off the page.
+
+	\section{The Measure}
+
+	A comfortable line holds somewhere between fifty and seventy characters. Wider, and the eye loses its way on the return sweep; narrower, and the text breaks into a nervous staccato of hyphens. Adjust the page margins in Bookmaker and watch the paragraphs reflow to the new measure.
+
+	\chapter{Reflowing the Text}
+
+	Change the page size or any margin and typeset again: the entire book reflows, the table of contents picks up the new page numbers, and the spreads settle into their new proportions. This is the whole point of separating content from layout.
+
+	\section{Working with Templates}
+
+	The spread template wraps the whole book: document class, geometry, running headers and footers. The TOC template decides how the front matter and table of contents are produced. Edit either one from the picker above the editor, or reset it to the built-in default.
+
+	\section{What Comes Next}
+
+	This first iteration keeps things deliberately small: no images, no chapter files, no styles beyond what the templates declare. Set your page, write your chapters, and typeset.
+	"""#
+}
+
+struct BookDocument: FileDocument, Codable, Equatable {
+	static var readableContentTypes: [UTType] { [.bookmakerBook] }
+
+	var settings = PageSettings()
+	var spreadTemplate = DefaultTemplates.spread
+	var tocTemplate = DefaultTemplates.toc
+	var bodyText = DefaultTemplates.sampleBody
+
+	init() {}
+
+	init(configuration: ReadConfiguration) throws {
+		guard let data = configuration.file.regularFileContents else {
+			throw CocoaError(.fileReadCorruptFile)
+		}
+		self = try JSONDecoder().decode(BookDocument.self, from: data)
+	}
+
+	func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+		let encoder = JSONEncoder()
+		encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+		return FileWrapper(regularFileWithContents: try encoder.encode(self))
+	}
+
+	/// The complete LaTeX source: spread template with TOC, body and geometry filled in.
+	var assembledLaTeX: String {
+		spreadTemplate
+			.replacingOccurrences(of: "{{TOC}}", with: tocTemplate)
+			.replacingOccurrences(of: "{{BODY}}", with: bodyText)
+			.replacingOccurrences(of: "{{GEOMETRY}}", with: settings.geometryOptions)
+	}
+}

--- a/Bookmaker/Bookmaker/BookmakerApp.swift
+++ b/Bookmaker/Bookmaker/BookmakerApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct BookmakerApp: App {
+	var body: some Scene {
+		DocumentGroup(newDocument: BookDocument()) { file in
+			ContentView(document: file.$document)
+		}
+		.defaultSize(width: 1150, height: 760)
+	}
+}

--- a/Bookmaker/Bookmaker/ContentView.swift
+++ b/Bookmaker/Bookmaker/ContentView.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+import PDFKit
+
+struct ContentView: View {
+	@Binding var document: BookDocument
+	@StateObject private var typesetter = TypesetController()
+	@State private var editedSource: EditedSource = .bodyText
+	@State private var previewMode: PreviewMode = .spreads
+	@State private var showPreview = true
+	@State private var showPageSetup = true
+	@State private var autoTypeset = true
+	@State private var showLog = false
+	@State private var pendingTypeset: Task<Void, Never>?
+
+	enum EditedSource: String, CaseIterable, Identifiable {
+		case bodyText = "Body"
+		case spreadTemplate = "Spread Template"
+		case tocTemplate = "TOC Template"
+		var id: String { rawValue }
+	}
+
+	enum PreviewMode: String, CaseIterable, Identifiable {
+		case singlePages = "Single Pages"
+		case spreads = "Spreads"
+		var id: String { rawValue }
+		var pdfDisplayMode: PDFDisplayMode {
+			self == .spreads ? .twoUpContinuous : .singlePageContinuous
+		}
+	}
+
+	var body: some View {
+		HSplitView {
+			editorPane
+				.frame(minWidth: 350, maxWidth: .infinity, maxHeight: .infinity)
+			if showPreview {
+				previewPane
+					.frame(minWidth: 320, maxWidth: .infinity, maxHeight: .infinity)
+			}
+		}
+		.toolbar {
+			ToolbarItemGroup {
+				if typesetter.isTypesetting {
+					ProgressView()
+						.controlSize(.small)
+				}
+				Button {
+					typeset()
+				} label: {
+					Label("Typeset", systemImage: "play.fill")
+				}
+				.help("Typeset the book with pdflatex (⌘R)")
+				.keyboardShortcut("r", modifiers: .command)
+				.disabled(typesetter.isTypesetting)
+				Toggle(isOn: $autoTypeset) {
+					Label("Auto Typeset", systemImage: "arrow.triangle.2.circlepath")
+				}
+				.help("Automatically typeset after every change")
+				Toggle(isOn: $showPageSetup) {
+					Label("Page Setup", systemImage: "ruler")
+				}
+				.help("Show page size and margins")
+				Toggle(isOn: $showPreview) {
+					Label("Preview", systemImage: "sidebar.right")
+				}
+				.help("Show the PDF preview in a split view")
+			}
+		}
+		.onAppear {
+			typeset()
+		}
+		.onChange(of: document) { _ in
+			scheduleAutoTypeset()
+		}
+	}
+
+	// MARK: - Editor
+
+	private var editorPane: some View {
+		VStack(spacing: 0) {
+			HStack {
+				Picker("", selection: $editedSource) {
+					ForEach(EditedSource.allCases) { source in
+						Text(source.rawValue).tag(source)
+					}
+				}
+				.pickerStyle(.segmented)
+				.labelsHidden()
+				if editedSource != .bodyText {
+					Button("Reset to Default") {
+						resetCurrentTemplate()
+					}
+					.help("Replace this template with the built-in default")
+				}
+			}
+			.padding(8)
+			Divider()
+			TextEditor(text: sourceBinding)
+				.font(.system(size: 12, design: .monospaced))
+				.autocorrectionDisabled()
+			if showPageSetup {
+				Divider()
+				PageSetupView(settings: $document.settings)
+			}
+		}
+	}
+
+	private var sourceBinding: Binding<String> {
+		switch editedSource {
+		case .bodyText:
+			return $document.bodyText
+		case .spreadTemplate:
+			return $document.spreadTemplate
+		case .tocTemplate:
+			return $document.tocTemplate
+		}
+	}
+
+	private func resetCurrentTemplate() {
+		switch editedSource {
+		case .spreadTemplate:
+			document.spreadTemplate = DefaultTemplates.spread
+		case .tocTemplate:
+			document.tocTemplate = DefaultTemplates.toc
+		case .bodyText:
+			break
+		}
+	}
+
+	// MARK: - Preview
+
+	private var previewPane: some View {
+		VStack(spacing: 0) {
+			HStack {
+				Picker("", selection: $previewMode) {
+					ForEach(PreviewMode.allCases) { mode in
+						Text(mode.rawValue).tag(mode)
+					}
+				}
+				.pickerStyle(.segmented)
+				.labelsHidden()
+				.frame(width: 200)
+				Spacer()
+				if let pdf = typesetter.pdfDocument {
+					Text("\(pdf.pageCount) pages")
+						.font(.caption)
+						.foregroundColor(.secondary)
+				}
+			}
+			.padding(8)
+			Divider()
+			if let pdf = typesetter.pdfDocument {
+				PDFPreviewView(document: pdf, displayMode: previewMode.pdfDisplayMode)
+			} else if typesetter.isTypesetting {
+				Spacer()
+				ProgressView("Typesetting…")
+				Spacer()
+			} else {
+				Spacer()
+				Text("Press Typeset (⌘R) to build the PDF preview.")
+					.foregroundColor(.secondary)
+				Spacer()
+			}
+			if let error = typesetter.lastError {
+				Divider()
+				errorBar(error)
+			}
+		}
+	}
+
+	private func errorBar(_ error: String) -> some View {
+		VStack(alignment: .leading, spacing: 6) {
+			HStack {
+				Image(systemName: "exclamationmark.triangle.fill")
+					.foregroundColor(.yellow)
+				Text(error)
+					.font(.caption)
+					.lineLimit(2)
+					.textSelection(.enabled)
+				Spacer()
+				if !typesetter.log.isEmpty {
+					Button(showLog ? "Hide Log" : "Show Log") {
+						showLog.toggle()
+					}
+					.controlSize(.small)
+				}
+			}
+			if showLog {
+				ScrollView {
+					Text(typesetter.log)
+						.font(.system(size: 10, design: .monospaced))
+						.textSelection(.enabled)
+						.frame(maxWidth: .infinity, alignment: .leading)
+				}
+				.frame(height: 160)
+			}
+		}
+		.padding(8)
+	}
+
+	// MARK: - Typesetting
+
+	private func typeset() {
+		pendingTypeset?.cancel()
+		typesetter.typeset(source: document.assembledLaTeX)
+	}
+
+	private func scheduleAutoTypeset() {
+		guard autoTypeset else {
+			return
+		}
+		pendingTypeset?.cancel()
+		pendingTypeset = Task {
+			try? await Task.sleep(nanoseconds: 1_200_000_000)
+			if !Task.isCancelled {
+				typeset()
+			}
+		}
+	}
+}

--- a/Bookmaker/Bookmaker/Info.plist
+++ b/Bookmaker/Bookmaker/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Bookmaker Book</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.mekkablue.bookmaker.book</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.mekkablue.bookmaker.book</string>
+			<key>UTTypeDescription</key>
+			<string>Bookmaker Book</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>bookmaker</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Bookmaker/Bookmaker/LaTeXEngine.swift
+++ b/Bookmaker/Bookmaker/LaTeXEngine.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+struct TypesetResult {
+	var pdfData: Data?
+	var log: String
+	var errorMessage: String?
+}
+
+enum LaTeXEngine {
+	static let engineCandidates = [
+		"/Library/TeX/texbin/pdflatex",
+		"/opt/homebrew/bin/pdflatex",
+		"/usr/local/bin/pdflatex",
+		"/usr/texbin/pdflatex",
+	]
+
+	static func findEngine() -> String? {
+		for path in engineCandidates where FileManager.default.isExecutableFile(atPath: path) {
+			return path
+		}
+		// last resort: the user's login shell may know a PATH that the app does not
+		let process = Process()
+		process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+		process.arguments = ["-l", "-c", "command -v pdflatex"]
+		let pipe = Pipe()
+		process.standardOutput = pipe
+		process.standardError = Pipe()
+		do {
+			try process.run()
+			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
+			if process.terminationStatus == 0 {
+				let path = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+				if !path.isEmpty {
+					return path
+				}
+			}
+		} catch {
+			// fall through
+		}
+		return nil
+	}
+
+	static func typeset(source: String, in directory: URL) -> TypesetResult {
+		guard let engine = findEngine() else {
+			return TypesetResult(
+				pdfData: nil,
+				log: "",
+				errorMessage: "No pdflatex found. Install MacTeX or BasicTeX from https://tug.org/mactex/"
+			)
+		}
+		let pdfURL = directory.appendingPathComponent("main.pdf")
+		do {
+			try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+			try source.write(to: directory.appendingPathComponent("main.tex"), atomically: true, encoding: .utf8)
+
+			var lastLog = ""
+			// two passes so the table of contents and page references settle
+			for _ in 0 ..< 2 {
+				let (status, output) = runEngine(engine, in: directory)
+				lastLog = output
+				if status != 0 {
+					return TypesetResult(
+						pdfData: try? Data(contentsOf: pdfURL),
+						log: output,
+						errorMessage: firstErrorLine(in: output) ?? "pdflatex exited with status \(status)."
+					)
+				}
+			}
+			return TypesetResult(pdfData: try Data(contentsOf: pdfURL), log: lastLog, errorMessage: nil)
+		} catch {
+			return TypesetResult(pdfData: nil, log: "", errorMessage: error.localizedDescription)
+		}
+	}
+
+	private static func runEngine(_ engine: String, in directory: URL) -> (Int32, String) {
+		let process = Process()
+		process.executableURL = URL(fileURLWithPath: engine)
+		process.arguments = ["-interaction=nonstopmode", "-file-line-error", "main.tex"]
+		process.currentDirectoryURL = directory
+		let pipe = Pipe()
+		process.standardOutput = pipe
+		process.standardError = pipe
+		do {
+			try process.run()
+		} catch {
+			return (-1, "Could not launch \(engine): \(error.localizedDescription)")
+		}
+		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		process.waitUntilExit()
+		return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+	}
+
+	private static func firstErrorLine(in log: String) -> String? {
+		for line in log.split(separator: "\n") {
+			if line.hasPrefix("!") || line.range(of: #"^[^:]+\.tex:\d+:"#, options: .regularExpression) != nil {
+				return String(line)
+			}
+		}
+		return nil
+	}
+}

--- a/Bookmaker/Bookmaker/PDFPreviewView.swift
+++ b/Bookmaker/Bookmaker/PDFPreviewView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import PDFKit
+
+struct PDFPreviewView: NSViewRepresentable {
+	let document: PDFDocument?
+	var displayMode: PDFDisplayMode = .twoUpContinuous
+
+	func makeNSView(context: Context) -> PDFView {
+		let view = PDFView()
+		view.autoScales = true
+		view.displayMode = displayMode
+		view.displaysAsBook = displayMode == .twoUpContinuous
+		view.document = document
+		return view
+	}
+
+	func updateNSView(_ view: PDFView, context: Context) {
+		view.displayMode = displayMode
+		view.displaysAsBook = displayMode == .twoUpContinuous
+		if view.document !== document {
+			// keep the reading position across reflows
+			var pageIndex = 0
+			if let currentPage = view.currentPage, let oldDocument = view.document {
+				pageIndex = oldDocument.index(for: currentPage)
+			}
+			view.document = document
+			if let document = document, pageIndex > 0 {
+				let boundedIndex = min(pageIndex, document.pageCount - 1)
+				if boundedIndex > 0, let page = document.page(at: boundedIndex) {
+					view.go(to: page)
+				}
+			}
+		}
+	}
+}

--- a/Bookmaker/Bookmaker/PageSetupView.swift
+++ b/Bookmaker/Bookmaker/PageSetupView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct PageSetupView: View {
+	@Binding var settings: PageSettings
+
+	private static let presets: [(name: String, width: Double, height: Double)] = [
+		("A4", 210, 297),
+		("A5", 148, 210),
+		("B5", 176, 250),
+		("US Trade 6″×9″", 152.4, 228.6),
+	]
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 6) {
+			HStack(spacing: 12) {
+				Picker("Page:", selection: presetBinding) {
+					ForEach(Self.presets, id: \.name) { preset in
+						Text(preset.name).tag(preset.name)
+					}
+					Text("Custom").tag("Custom")
+				}
+				.fixedSize()
+				mmField("Width", $settings.paperWidth)
+				mmField("Height", $settings.paperHeight)
+			}
+			HStack(spacing: 12) {
+				Text("Margins:")
+				mmField("Top", $settings.marginTop)
+				mmField("Bottom", $settings.marginBottom)
+				mmField("Inner", $settings.marginInner)
+				mmField("Outer", $settings.marginOuter)
+			}
+		}
+		.padding(10)
+	}
+
+	private var presetBinding: Binding<String> {
+		Binding(
+			get: {
+				Self.presets.first { $0.width == settings.paperWidth && $0.height == settings.paperHeight }?.name ?? "Custom"
+			},
+			set: { name in
+				if let preset = Self.presets.first(where: { $0.name == name }) {
+					settings.paperWidth = preset.width
+					settings.paperHeight = preset.height
+				}
+			}
+		)
+	}
+
+	private func mmField(_ label: String, _ value: Binding<Double>) -> some View {
+		HStack(spacing: 4) {
+			Text(label)
+				.font(.caption)
+				.foregroundColor(.secondary)
+			TextField("", value: value, format: .number)
+				.textFieldStyle(.roundedBorder)
+				.multilineTextAlignment(.trailing)
+				.frame(width: 52)
+			Text("mm")
+				.font(.caption)
+				.foregroundColor(.secondary)
+		}
+	}
+}

--- a/Bookmaker/Bookmaker/TypesetController.swift
+++ b/Bookmaker/Bookmaker/TypesetController.swift
@@ -1,0 +1,48 @@
+import Foundation
+import PDFKit
+
+@MainActor
+final class TypesetController: ObservableObject {
+	@Published var pdfDocument: PDFDocument?
+	@Published var isTypesetting = false
+	@Published var lastError: String?
+	@Published var log = ""
+
+	private let workDirectory: URL
+	private var queuedSource: String?
+
+	init() {
+		workDirectory = FileManager.default.temporaryDirectory
+			.appendingPathComponent("Bookmaker-\(UUID().uuidString)", isDirectory: true)
+	}
+
+	func typeset(source: String) {
+		if isTypesetting {
+			// remember the newest source and run it as soon as the current pass finishes
+			queuedSource = source
+			return
+		}
+		isTypesetting = true
+		lastError = nil
+		let directory = workDirectory
+		Task.detached(priority: .userInitiated) {
+			let result = LaTeXEngine.typeset(source: source, in: directory)
+			await MainActor.run {
+				self.finish(with: result)
+			}
+		}
+	}
+
+	private func finish(with result: TypesetResult) {
+		isTypesetting = false
+		log = result.log
+		lastError = result.errorMessage
+		if let data = result.pdfData, let pdf = PDFDocument(data: data) {
+			pdfDocument = pdf
+		}
+		if let queued = queuedSource {
+			queuedSource = nil
+			typeset(source: queued)
+		}
+	}
+}

--- a/Bookmaker/README.md
+++ b/Bookmaker/README.md
@@ -1,0 +1,48 @@
+# Bookmaker
+
+A small LaTeX-based layout editor for typesetting a book, as a native Mac app (SwiftUI). First iteration: text only, no images.
+
+![](https://img.shields.io/badge/platform-macOS%2013%2B-blue)
+
+## Requirements
+
+- macOS 13 Ventura or later, Xcode 15 or later to build.
+- A TeX distribution providing `pdflatex`: [MacTeX or BasicTeX](https://tug.org/mactex/). Bookmaker looks in `/Library/TeX/texbin`, Homebrew paths, and finally asks your login shell.
+
+## Build & Run
+
+Open `Bookmaker.xcodeproj` in Xcode and press ⌘R. The app is unsandboxed so it can launch `pdflatex`.
+
+## How It Works
+
+A **Bookmaker Book** document (`.bookmaker`, JSON) holds four things:
+
+1. **Page settings** — paper size and the four book margins (top, bottom, inner, outer) in millimeters, with presets for A4, A5, B5, and US Trade 6″×9″.
+2. **Spread template** — the LaTeX wrapper for the whole book: document class, `geometry` setup, running headers/footers for regular spreads.
+3. **TOC template** — how the front matter and table of contents are produced.
+4. **Body** — your chapters, as plain LaTeX (`\chapter`, `\section`, paragraphs).
+
+On typeset, the templates and body are assembled into one `main.tex` via placeholders:
+
+| Placeholder | Replaced with |
+|---|---|
+| `{{GEOMETRY}}` | `geometry` package options from the page settings |
+| `{{TOC}}` | the TOC template |
+| `{{BODY}}` | the body text |
+
+`pdflatex` runs twice (so the TOC and page numbers settle) in a private temp folder, and the result appears in the preview.
+
+## UI
+
+- **Editor pane** with a picker to switch between Body, Spread Template, and TOC Template. Templates have a *Reset to Default* button.
+- **Page setup bar** (toggleable) for paper size and margins. Change a margin, and the whole multipage document reflows.
+- **PDF preview** in an optional split view (toolbar toggle), with *Single Pages* or *Spreads* display, keeping your reading position across reflows.
+- **Typeset** button (⌘R) plus an *Auto Typeset* toggle that re-typesets ~1 second after you stop editing.
+- Errors show a summary bar with the full LaTeX log one click away.
+
+## Not Yet (Ideas for Later)
+
+- Images and figures
+- Multiple chapters as separate files
+- Named template library, more page presets
+- Export/print of the finished PDF (for now: typeset, then grab `main.pdf` from the temp folder, or print from Preview after opening the PDF)


### PR DESCRIPTION
## Summary

First iteration of **Bookmaker**, a native Mac app (SwiftUI, document-based) for typesetting a book with LaTeX. Lives in a new top-level `Bookmaker/` folder with its own Xcode project — no Python, independent of the Glyphs scripts.

A `.bookmaker` document (JSON) holds page settings, two editable templates, and the body text:

- **Page setup**: paper size presets (A4, A5, B5, US Trade 6″×9″) plus the four book margins (top, bottom, inner, outer) in mm. Changing any value reflows the whole multipage document.
- **Template management**: one template for regular spreads (document class, geometry, running headers/footers) and one for the TOC (front matter, `\tableofcontents`, main matter). Both editable in the app, each with a *Reset to Default* button.
- **Assembly**: templates and body are merged via `{{GEOMETRY}}` / `{{TOC}}` / `{{BODY}}` placeholders into one `main.tex`; `pdflatex` runs twice in a private temp folder so the TOC and page numbers settle.
- **PDF preview in optional split view**: toolbar toggle, *Single Pages* or *Spreads* display mode, page count, and the reading position is preserved across reflows.
- **Typesetting UX**: Typeset button (⌘R), *Auto Typeset* toggle with ~1.2 s debounce after edits, error bar with the first LaTeX error and the full log one click away.

No images in this iteration, per the request.

## Requirements

- macOS 13+, Xcode 15+ to build (app is unsandboxed so it can launch `pdflatex`).
- A TeX distribution (MacTeX/BasicTeX); the app searches `/Library/TeX/texbin`, Homebrew paths, then asks the login shell. Only `geometry` and `fancyhdr` are required, both in BasicTeX.

## Testing

⚠️ Written in a Linux CI container: no Xcode/swiftc or TeX available, so the app has **not been build-tested**. Verified here: Info.plist XML validity, pbxproj structure, and a simulated template assembly producing well-formed LaTeX with all placeholders resolved. Please open `Bookmaker/Bookmaker.xcodeproj` and build — happy to fix anything the compiler flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FKVmkvRSEbmaBcFkJKMKf

---
_Generated by [Claude Code](https://claude.ai/code/session_019FKVmkvRSEbmaBcFkJKMKf)_