### PR TITLE
Contextual Cycler: match the tutorial's cycling code

### DIFF
--- a/Features/Contextual Cycler.py
+++ b/Features/Contextual Cycler.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
 __doc__ = """
-Builds contextual alternate (calt) feature code that cycles through numbered glyph alternates, so that repeated glyphs step through their variants (default → .cv01 → .cv02 → … → default). Glyphs are grouped by how many alternates they have: @One0/@One1 for glyphs with one alternate, @Two0/@Two1/@Two2 for two, and so on; everything else lands in @Etc. See https://glyphsapp.com/learn/features-part-3-advanced-contextual-alternates
+Builds contextual alternate (calt) feature code that cycles through numbered glyph alternates, so that repeated glyphs step through their variants (default → .cv01 → .cv02 → … → default), following the cycling technique from https://glyphsapp.com/learn/features-part-3-advanced-contextual-alternates
+Instead of the tutorial’s @Voc/@Con split, glyphs are grouped by how many alternates they have: @One0/@One1 for glyphs with one alternate, @Two0/@Two1/@Two2 for two, and so on; everything else lands in @Etc. The cycle keeps counting across intervening glyphs of other groups, just like in the tutorial.
 """
 
 import vanilla
@@ -30,13 +31,14 @@ class ContextualCycler(mekkaObject):
 	prefDict = {
 		"targetFeature": "calt",
 		"suffixes": ".cv, .ss",
+		"maxIntervening": 2,
 		"separateFeatureEntry": False,
 	}
 
 	def __init__(self):
 		# Window 'self.w':
 		windowWidth = 360
-		windowHeight = 175
+		windowHeight = 197
 		windowWidthResize = 400  # user can resize width by this value
 		windowHeightResize = 0  # user can resize height by this value
 		self.w = vanilla.FloatingWindow(
@@ -69,6 +71,13 @@ class ContextualCycler(mekkaObject):
 		self.w.targetFeatureText.setToolTip(tooltip)
 		self.w.targetFeatureUpdate = UpdateButton((-inset - 18, linePos - 1, -inset, 18), callback=self.update)
 		self.w.targetFeatureUpdate.setToolTip("Reset to defaults: ‘calt’")
+		linePos += lineHeight
+
+		self.w.maxInterveningText = vanilla.TextBox((inset, linePos + 3, tabIndent, 14), "Cycle across up to:", sizeStyle="small", selectable=True)
+		self.w.maxIntervening = vanilla.PopUpButton((inset + tabIndent, linePos, 130, 18), ["0 other glyphs", "1 other glyph", "2 other glyphs", "3 other glyphs", "4 other glyphs"], callback=self.SavePreferences, sizeStyle="small")
+		tooltip = "How many glyphs of other groups may sit between two cycling glyphs while the cycle keeps counting. As in the tutorial, the default of 2 covers direct pairs, one intervening glyph (e.g. a vowel between two consonants), and two intervening glyphs."
+		self.w.maxIntervening.setToolTip(tooltip)
+		self.w.maxInterveningText.setToolTip(tooltip)
 		linePos += lineHeight
 
 		self.w.separateFeatureEntry = vanilla.CheckBox((inset + 2, linePos, -inset, 20), "Separate feature entry (i.e. do not reuse existing feature)", value=False, callback=self.SavePreferences, sizeStyle="small")
@@ -155,7 +164,10 @@ class ContextualCycler(mekkaObject):
 		return groups, usedNames
 
 	def buildClasses(self, thisFont, groups, usedNames):
-		"""Creates/updates the @<Word><position> classes and the @Etc leftover class."""
+		"""
+		Creates/updates the @<Word><position> classes and the @Etc leftover class.
+		Returns (classCount, etcExists).
+		"""
 		classCount = 0
 		for count in sorted(groups):
 			word = numberWord(count)
@@ -169,27 +181,65 @@ class ContextualCycler(mekkaObject):
 
 		# everything that is not part of a cycle goes into @Etc:
 		etcNames = [glyph.name for glyph in thisFont.glyphs if glyph.export and glyph.name not in usedNames]
-		if etcNames:
+		etcExists = bool(etcNames)
+		if etcExists:
 			print("\t%s" % createOTClass(className=self.etcClassName, classGlyphNames=etcNames, targetFont=thisFont))
 			classCount += 1
 
-		return classCount
+		return classCount, etcExists
 
-	def buildFeatureCode(self, groups):
+	def otherClassMembers(self, groups, currentCount, etcExists):
 		"""
-		Assembles the cycling feature code. For each group with positions 0…k, the
-		current glyph (always written as the default @<Word>0) is advanced to the next
-		alternate based on the preceding glyph’s position, wrapping back to the default:
-			sub @Word0 @Word0' by @Word1;
-			sub @Word1 @Word0' by @Word2;
+		Returns the class names that make up the ‘other’ context for a cycle group:
+		every position class that does NOT belong to the current group, plus @Etc.
+		Mirrors the tutorial’s [@Voc0 @Voc1 @Voc2 @Etc] context for the consonant cycle.
+		"""
+		members = []
+		for count in sorted(groups):
+			if count == currentCount:
+				continue
+			word = numberWord(count)
+			for position in range(count + 1):
+				members.append("@%s%i" % (word, position))
+		if etcExists:
+			members.append("@%s" % self.etcClassName)
+		return members
+
+	def buildFeatureCode(self, groups, etcExists, maxIntervening):
+		"""
+		Assembles the cycling feature code, following the tutorial at
+		https://glyphsapp.com/learn/features-part-3-advanced-contextual-alternates
+
+		For each group with positions 0…k, the current glyph (always written as the
+		default @<Word>0) is advanced to the next alternate based on the preceding
+		glyph of the SAME group. As in the tutorial, the cycle keeps counting even
+		when up to ‘maxIntervening’ glyphs of OTHER groups sit in between — the
+		context [@OtherClasses… @Etc] is inserted between the anchor and the marked
+		glyph (0 = direct pair, 1 = one intervening glyph, etc.):
+			sub @Word0 @Word0' by @Word1;                       # direct pair
+			sub @Word0 [@Other… @Etc] @Word0' by @Word1;        # one glyph between
+			sub @Word0 [@Other… @Etc] [@Other… @Etc] @Word0' by @Word1;  # two between
 			…
+		Reaching the last position falls through to the default, so the identity
+		wrap-around rule is left implicit.
 		"""
 		featureCode = ""
 		for count in sorted(groups):
 			word = numberWord(count)
+			otherMembers = self.otherClassMembers(groups, count, etcExists)
+			otherClass = "[%s]" % " ".join(otherMembers) if otherMembers else None
+
 			featureCode += "lookup %sCycle {\n" % word
-			for position in range(count):
-				featureCode += "\tsub @%s%i @%s0' by @%s%i;\n" % (word, position, word, word, position + 1)
+			for distance in range(maxIntervening + 1):
+				if distance > 0:
+					if otherClass is None:
+						break  # no other glyphs available to skip over
+					featureCode += "\t# cycle across %i intervening glyph%s:\n" % (distance, "" if distance == 1 else "s")
+				else:
+					featureCode += "\t# direct pairs:\n"
+				interveners = ("%s " % otherClass) * distance
+				for position in range(count):
+					featureCode += "\tsub @%s%i %s@%s0' by @%s%i;\n" % (word, position, interveners, word, word, position + 1)
 			featureCode += "} %sCycle;\n\n" % word
 		return featureCode.strip()
 
@@ -250,10 +300,11 @@ class ContextualCycler(mekkaObject):
 			print()
 
 			# build classes:
-			classCount = self.buildClasses(thisFont, groups, usedNames)
+			classCount, etcExists = self.buildClasses(thisFont, groups, usedNames)
 
 			# build cycling feature code:
-			featureCode = self.buildFeatureCode(groups)
+			maxIntervening = self.prefInt("maxIntervening")
+			featureCode = self.buildFeatureCode(groups, etcExists, maxIntervening)
 			print()
 			print("\t%s" % createOTFeature(
 				featureName=targetFeature,

--- a/Features/Contextual Cycler.py
+++ b/Features/Contextual Cycler.py
@@ -7,8 +7,105 @@ Instead of the tutorial’s @Voc/@Con split, glyphs are grouped by how many alte
 """
 
 import vanilla
-from GlyphsApp import Glyphs, Message
-from mekkablue import mekkaObject, UpdateButton, createOTFeature, createOTClass, reportFontName
+from GlyphsApp import Glyphs, GSFeature, GSClass, Message
+from mekkablue import mekkaObject, UpdateButton, reportFontName
+
+
+# The feature-code helpers are defined locally (rather than imported from mekkablue)
+# so the script keeps working even if an older mekkablue module is still cached in the
+# running Glyphs Python session. They mirror the versions in mekkablue/__init__.py.
+
+
+def updatedCode(oldCode, beginSig, endSig, newCode):
+	"""Replaces text in oldCode with newCode, but only between beginSig and endSig."""
+	beginOffset = oldCode.find(beginSig)
+	endOffset = oldCode.find(endSig) + len(endSig)
+	newCode = oldCode[:beginOffset] + beginSig + newCode + "\n" + endSig + oldCode[endOffset:]
+	return newCode
+
+
+def createOTFeature(featureName="calt", featureCode="# empty feature code", targetFont=None, codeSig="DEFAULT-CODE-SIGNATURE", createSeparateEntry=False):
+	"""
+	Creates or updates an OpenType feature in the font, wrapping the code in
+	# BEGIN/# END signature comments for easy in-place updating.
+	Returns a status message in form of a string.
+	"""
+	if targetFont is None:
+		targetFont = Glyphs.font
+	if targetFont is None:
+		return "🛑 ERROR: Could not create OT feature %s. No font detected." % featureName
+
+	beginSig = "# BEGIN " + codeSig + "\n"
+	endSig = "# END " + codeSig + "\n"
+
+	featuresWithTag = [f for f in targetFont.features if f.name == featureName and f.name]
+	featureExists = len(featuresWithTag) > 0
+	featuresWithSig = [f for f in targetFont.features if beginSig in f.code and endSig in f.code and f.active]
+	sigExists = len(featuresWithSig) > 0
+
+	if sigExists:
+		for targetFeature in featuresWithSig:
+			# replace old code with new code:
+			targetFeature.code = updatedCode(targetFeature.code, beginSig, endSig, featureCode)
+		return "✅ Updated %i existing OT feature%s ‘%s’." % (
+			len(featuresWithSig),
+			"" if len(featuresWithSig) == 1 else "s",
+			featureName,
+		)
+	elif featureExists and not createSeparateEntry:
+		# feature already exists:
+		targetFeature = targetFont.features[featureName]  # take the first available one
+		targetFeature.code += "\n" + beginSig + featureCode + "\n" + endSig
+		return "✅ Added code to first available OT feature ‘%s’." % featureName
+	else:
+		# create feature with new code:
+		newFeature = GSFeature()
+		newFeature.name = featureName
+		newFeature.code = beginSig + featureCode + "\n" + endSig
+		targetFont.features.append(newFeature)
+		return "🌟 Created new OT feature entry ‘%s’" % featureName
+
+
+def createOTClass(className="@default", classGlyphNames=None, targetFont=None, automate=False):
+	"""
+	Creates or updates an OpenType class in the font.
+	Returns a status message in form of a string.
+	"""
+	if targetFont is None:
+		targetFont = Glyphs.font
+	if classGlyphNames is None and targetFont is not None:
+		classGlyphNames = [layer.parent.name for layer in targetFont.selectedLayers]
+
+	if targetFont is None or not (classGlyphNames or automate):
+		return "🛑 ERROR: Could not create OT class %s. Missing either font or glyph names, or both." % className
+
+	className = className.lstrip("@")  # strip '@' from beginning
+	classCode = " ".join(classGlyphNames)
+	otClass = None
+
+	# build or update class:
+	if className in [c.name for c in targetFont.classes]:
+		otClass = targetFont.classes[className]
+		otClass.code = classCode
+		returnText = "✅ Updated existing OT class ‘%s’." % className
+	else:
+		otClass = GSClass()
+		otClass.name = className
+		otClass.code = classCode
+		targetFont.classes.append(otClass)
+		returnText = "🌟 Created new OT class: ‘%s’" % className
+
+	# automate the class:
+	if automate and otClass is not None:
+		if Glyphs.versionNumber >= 3:
+			if otClass.canBeAutomated():
+				otClass.automatic = True
+		else:
+			otClass.automatic = True
+		returnText = returnText.rstrip(".") + " (automated)."
+
+	return returnText
+
 
 # Spelled-out numbers used to name the cycle classes (@One0, @Two1, …):
 numberWords = (


### PR DESCRIPTION
## What

Follow-up to #421 (already merged). Reworks the code that **Features → Contextual Cycler** generates so it follows the cycling technique in [Features, part 3: advanced contextual alternates](https://glyphsapp.com/learn/features-part-3-advanced-contextual-alternates) more faithfully.

## Why

The first version only emitted the direct `sub @Word0 @Word0' by @Word1;` pairs, so a cycle only advanced when two cycling glyphs were immediately adjacent. The tutorial instead keeps the cycle counting across intervening glyphs of the *other* category — that is the whole reason it splits glyphs into separate groups (`@Con`/`@Voc` there, `@One`/`@Two`/… here) and keeps an `@Etc` bucket.

## Change

For each count-group, the feature code now emits, in addition to the direct pairs, rules with an `[@Other… @Etc]` context inserted between the anchor and the marked glyph — one copy per intervening glyph — mirroring the tutorial's `consonant-other-consonant` and `consonant-other-other-consonant` patterns:

```fea
lookup TwoCycle {
	# direct pairs:
	sub @Two0 @Two0' by @Two1;
	sub @Two1 @Two0' by @Two2;
	# cycle across 1 intervening glyph:
	sub @Two0 [@One0 @One1 @Etc] @Two0' by @Two1;
	sub @Two1 [@One0 @One1 @Etc] @Two0' by @Two2;
	# cycle across 2 intervening glyphs:
	sub @Two0 [@One0 @One1 @Etc] [@One0 @One1 @Etc] @Two0' by @Two1;
	sub @Two1 [@One0 @One1 @Etc] [@One0 @One1 @Etc] @Two0' by @Two2;
} TwoCycle;
```

The `[@Other… @Etc]` context is every position class that does **not** belong to the current group, plus `@Etc` — so `@Etc` now has a concrete role. The last position falls through to the default, so the identity wrap-around rule stays implicit.

## Options

Adds a **“Cycle across up to N other glyphs”** popup (default **2**, matching the tutorial's coverage of direct pairs, one intervening glyph, and two intervening glyphs). The code still wraps everything in `# BEGIN CONTEXTUAL CYCLER` / `# END CONTEXTUAL CYCLER` signatures for in-place updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8a5uUWLmNt3MABYctUchX

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8a5uUWLmNt3MABYctUchX)_