### PR TITLE
Reproject Virtual Master locations in Reproject Axis

### DIFF
--- a/Interpolation/Reproject Axis.py
+++ b/Interpolation/Reproject Axis.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
 __doc__ = """
-Rescale (reproject) all design-space values of an axis to a new min/max range. Recalculates master and instance coordinates, brace (intermediate) and bracket (alternate) layer coordinates, and the axis values in condition feature code.
+Rescale (reproject) all design-space values of an axis to a new min/max range. Recalculates master and instance coordinates, brace (intermediate) and bracket (alternate) layer coordinates, Virtual Master locations, and the axis values in condition feature code.
 """
 
 import re
@@ -80,12 +80,12 @@ class ReprojectAxis(mekkaObject):
 		linePos += lineHeight
 
 		self.w.roundValues = vanilla.CheckBox((inset, linePos, -inset, 20), "Round reprojected values to full coordinates", value=True, callback=self.SavePreferences, sizeStyle="small")
-		self.w.roundValues.setToolTip("If enabled, all reprojected values (masters, instances, brace and bracket layers, and feature code) are rounded to whole numbers. Otherwise, fractional values are kept (rounded to 4 decimal places).")
+		self.w.roundValues.setToolTip("If enabled, all reprojected values (masters, instances, brace and bracket layers, Virtual Masters, and feature code) are rounded to whole numbers. Otherwise, fractional values are kept (rounded to 4 decimal places).")
 		linePos += lineHeight
 
 		# Run Button:
 		self.w.runButton = vanilla.Button((-110 - inset, -20 - inset, -inset, -inset), "Reproject", callback=self.ReprojectAxisMain)
-		self.w.runButton.setToolTip("Rescale masters, instances, brace and bracket layers, and condition feature code of the chosen axis from the current onto the new range.")
+		self.w.runButton.setToolTip("Rescale masters, instances, brace and bracket layers, Virtual Masters, and condition feature code of the chosen axis from the current onto the new range.")
 		self.w.setDefaultButton(self.w.runButton)
 
 		# Load Settings:
@@ -195,6 +195,25 @@ class ReprojectAxis(mekkaObject):
 					print("\t🔤 Updated condition code in ‘%s’" % container.name)
 		return editCount[0]
 
+	def reprojectVirtualMasters(self, font, axisName, reproject, roundValues):
+		"""Rescale Locations in 'Virtual Master' custom parameters that reference the chosen axis (by full name). Returns number of edited entries."""
+		count = 0
+		for parameter in font.customParameters:
+			if parameter.name != "Virtual Master":
+				continue
+			changed = False
+			newCoordinates = []
+			for coord in parameter.value:
+				coordDict = dict(coord)
+				if coordDict.get("Axis") == axisName:
+					coordDict["Location"] = cleanNumber(reproject(float(coordDict["Location"])), forceInt=roundValues)
+					changed = True
+					count += 1
+				newCoordinates.append(coordDict)
+			if changed:
+				parameter.value = newCoordinates
+		return count
+
 	def ReprojectAxisMain(self, sender=None):
 		try:
 			# clear macro window log:
@@ -300,6 +319,10 @@ class ReprojectAxis(mekkaObject):
 								bracketCount += 1
 				print("🔲 Reprojected %i brace layer coordinate%s." % (braceCount, "" if braceCount == 1 else "s"))
 				print("🔳 Reprojected %i bracket layer rule%s." % (bracketCount, "" if bracketCount == 1 else "s"))
+
+				# Virtual Masters:
+				virtualMasterCount = self.reprojectVirtualMasters(font, axisName, reproject, roundValues)
+				print("🧬 Reprojected %i Virtual Master location%s." % (virtualMasterCount, "" if virtualMasterCount == 1 else "s"))
 
 				# condition feature code:
 				conditionCount = self.reprojectFeatureConditions(font, axisTag, reproject, roundValues)

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ All the scripts show a **tooltip** when you hover the mouse pointer over their m
 * **Re-interpolate Selected Layers:** Batch-reinterpolates all selected layers. Same as the Re-Interpolate command in the Layers palette, but for multiple selections.
 * **Remove All Non-Master Layers:** Deletes all layers which are neither master layers, nor brace layers, nor bracket layers. Useful for getting rid of backup layers.
 * **Report Instance Interpolations:** Outputs master coefficients for each instance in Macro Window. Tells you which masters are involved in interpolating a specific instance, and to which extent.
-* **Reproject Axis:** Rescales all design-space values of an axis onto a new min/max range. Recalculates master and instance coordinates, brace (intermediate) and bracket (alternate) layer coordinates, and the axis values in condition feature code.
+* **Reproject Axis:** Rescales all design-space values of an axis onto a new min/max range. Recalculates master and instance coordinates, brace (intermediate) and bracket (alternate) layer coordinates, Virtual Master locations, and the axis values in condition feature code.
 * **Reset Axis Mappings:** Inserts (or resets) a default Axis Mappings parameter for all style values currently present in the font. Ignores style values outside the designspace bounds defined by the masters.
 * **Set Weight Axis Locations in Instances:** Will set weight axis location parameters for all instances, and sync them with their respective usWeightClass. Will set the width axis coordinates to the spec defaults for usWidthClass, if they have not been set yet. Otherwise will keep them as is.
 * **Short Segment Finder:** Goes through all interpolations and finds segments shorter than a user-specified threshold length.


### PR DESCRIPTION
## Summary

Follow-up to the merged Reproject Axis script (#425, #426). Adds support for **Virtual Master** custom parameters.

Virtual Masters store their axis locations by full axis name (e.g. `Weight`) inside the parameter's `value` list — `[{"Axis": "Weight", "Location": 30}, ...]` — rather than by axis ID, so they weren't reached by the axisId-based logic used for masters, instances, and special layers. This adds a dedicated pass that rescales the `Location` of any Virtual Master coordinate entry matching the chosen axis's name, respecting the existing "Round reprojected values to full coordinates" option.

## Testing

- `python3 -m py_compile` passes.
- `flake8` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4yDrGqW1N2DQDshpWt66h)_