### PR TITLE
Variable Font Test HTML: play-all button for animating every axis

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -927,7 +927,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 
 			const animStates = {};
 			const animFreq = [0, 1/2.1, 1/1.3, 1/0.8]; // cycles/second for speeds 0-3
-			function toggleAnimation(axisTag) {
+			function setAxisSpeed(axisTag, newSpeed) {
 				if (!animStates[axisTag]) {
 					animStates[axisTag] = {speed: 0, animId: null, startTime: 0, phaseOffset: 0};
 				}
@@ -945,11 +945,11 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 					currentPhase = Math.acos(Math.max(-1, Math.min(1, ratio)));
 				}
 				if (state.animId) { cancelAnimationFrame(state.animId); state.animId = null; }
-				state.speed = (state.speed + 1) %% 4;
+				state.speed = newSpeed;
 				const btn = document.getElementById('play_' + axisTag);
 				const symbols = ['▶', '①', '②', '③'];
-				btn.textContent = symbols[state.speed];
-				if (state.speed === 0) return;
+				if (btn) btn.textContent = symbols[state.speed];
+				if (state.speed === 0) { updatePlayAllButton(); return; }
 				state.startTime = now;
 				state.phaseOffset = currentPhase;
 				function animFrame(time) {
@@ -964,6 +964,11 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 					s.animId = requestAnimationFrame(animFrame);
 				}
 				state.animId = requestAnimationFrame(animFrame);
+				updatePlayAllButton();
+			}
+			function toggleAnimation(axisTag) {
+				const current = animStates[axisTag] ? animStates[axisTag].speed : 0;
+				setAxisSpeed(axisTag, (current + 1) %% 4);
 			}
 			function pauseAllAnimations() {
 				for (const axisTag in animStates) {
@@ -974,6 +979,32 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 						const btn = document.getElementById('play_' + axisTag);
 						if (btn) btn.textContent = '▶';
 					}
+				}
+				updatePlayAllButton();
+			}
+			function anyAxisAnimating() {
+				for (const axisTag in animStates) {
+					if (animStates[axisTag].speed > 0) return true;
+				}
+				return false;
+			}
+			function updatePlayAllButton() {
+				const btn = document.getElementById('playAll');
+				if (btn) btn.textContent = anyAxisAnimating() ? '⏸️' : '▶️';
+			}
+			function playAllAxes() {
+				// speeds cycle 1,2,3,1,2,3,… so multiple axes cover more of the design space
+				const btns = document.getElementsByClassName('playBtn');
+				for (let i = 0; i < btns.length; i++) {
+					const axisTag = btns[i].id.substring(5); // strip "play_"
+					setAxisSpeed(axisTag, (i %% 3) + 1);
+				}
+			}
+			function togglePlayAll() {
+				if (anyAxisAnimating()) {
+					pauseAllAnimations();
+				} else {
+					playAllAxes();
 				}
 			}
 			let gridTooltip = null;
@@ -1306,6 +1337,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 				<a onclick="toggleType();" id="type" class="emojiButton" title="Switch font format (TTF/OTF, WOFF, WOFF2)">&nbsp;###TTW1W2###</a>
 				<a onclick="reloadFontFace();" id="reload" class="emojiButton" title="Reload the font from disk (Ctrl-U)">&nbsp;🔄</a>
 				<a onclick="toggleGridView();" id="gridToggle" class="emojiButton" title="Toggle grid view of all glyphs (Ctrl-G)">&nbsp;🔡&nbsp;</a>
+				<a onclick="togglePlayAll();" id="playAll" class="emojiButton" title="Animate all axes / pause (Ctrl-P)">&nbsp;▶️&nbsp;</a>
 
 			<!-- Samsa -->
 				%s

--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -1131,7 +1131,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 					} else if (event.code == 'KeyG') {
 						toggleGridView();
 					} else if (event.code == 'KeyP') {
-						pauseAllAnimations();
+						togglePlayAll();
 					} else if (event.code == 'Period') {
 						styleMenu.selectedIndex = (styleMenu.selectedIndex + 1) %% styleMenuLength;
 						setStyle(styleMenu.value);
@@ -1365,7 +1365,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 
 	<!-- Disclaimer -->
 	<p id="helptext" onmouseleave="vanish(this);">
-		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> pause all <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
+		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> play/pause all <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
 	</p>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

Adds a single **play-all** control to the generated variable-font test page.

- New **▶️ button** placed right after the grid button. Clicking it animates every interpolating axis at once, with staggered speeds: 1st axis at speed 1, 2nd at speed 2, 3rd at speed 3, 4th back at speed 1, and so on (cycling `(i % 3) + 1`) — so when several axes run together they cover more of the design space.
- The button turns into **⏸️** while animating. Pressing it stops every axis, identical to **Ctrl-P**.
- Internals: the per-axis start logic was factored out into `setAxisSpeed()`, reused by both the individual axis play buttons and the new play-all. A small `updatePlayAllButton()` keeps the ▶️/⏸️ icon in sync no matter how animation state changes (individual buttons, Ctrl-P, or play-all).

## Test plan

- [ ] Generate the test HTML from a variable font with 2+ axes; confirm the ▶️ button appears after the 🔡 grid button
- [ ] Click ▶️ → all axes animate; the first cycles fastest-to-slowest pattern (1,2,3,1,…); the button shows ⏸️ and each axis button shows its speed ①/②/③
- [ ] Click ⏸️ → all animation stops, button returns to ▶️, axis buttons return to ▶
- [ ] Start play-all, then press Ctrl-P → animation stops and the ▶️/⏸️ button reflects the stopped state
- [ ] Toggle an individual axis on/off and confirm the play-all button icon updates accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXBaror5ZdxFx577Ru3ufL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXBaror5ZdxFx577Ru3ufL)_