### PR TITLE
Variable Font Test HTML: use feature.fullName() for OT feature tooltips

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -453,21 +453,32 @@ def featureTitle(featureTag):
 	return featureTag
 
 
+def featureFullName(thisFeature):
+	# Prefer the human-readable name Glyphs provides, fall back to our own map.
+	try:
+		fullName = thisFeature.fullName()
+		if fullName:
+			return fullName
+	except:
+		pass
+	return featureTitle(thisFeature.name)
+
+
 def featureListForFont(thisFont):
 	returnString = ""
-	featureList = [(f.name, f.notes) for f in thisFont.features if f.name not in ("ccmp", "aalt", "locl", "kern", "calt", "liga", "clig", "rlig", "rclt", "rvrn") and not f.disabled()]
-	for (f, n) in featureList:
+	featureList = [(f.name, f.notes, featureFullName(f)) for f in thisFont.features if f.name not in ("ccmp", "aalt", "locl", "kern", "calt", "liga", "clig", "rlig", "rclt", "rvrn") and not f.disabled()]
+	for (f, n, fullName) in featureList:
 		# <input type="checkbox" name="kern" id="kern" value="kern" class="otFeature" onchange="updateFeatures()" checked><label for="kern" class="otFeatureLabel">kern</label>
 		if f.startswith("ss") and n and n.startswith("Name:"):
 			# stylistic set name:
 			setName = n.splitlines()[0][5:].strip()
 			featureItem = '\t\t\t\t<input type="checkbox" name="%s" id="%s" value="%s" class="otFeature" onchange="updateFeatures()"><label for="%s" class="otFeatureLabel" title="%s">%s<span class="tooltip">%s</span></label>\n' % (
-				f, f, f, f, featureTitle(f), f, setName
+				f, f, f, f, fullName, f, setName
 			)
 		else:
 			# non-ssXX features
 			featureItem = '\t\t\t\t<input type="checkbox" name="%s" id="%s" value="%s" class="otFeature" onchange="updateFeatures()"><label for="%s" class="otFeatureLabel" title="%s">%s</label>\n' % (
-				f, f, f, f, featureTitle(f), f
+				f, f, f, f, fullName, f
 			)
 		if featureItem not in returnString:
 			returnString += featureItem


### PR DESCRIPTION
## Summary

The dynamic OT feature buttons in the generated test page now show the human-readable feature name from Glyphs' `feature.fullName()` as a subtle native `title` tooltip.

- New `featureFullName(feature)` helper returns `feature.fullName()` when available, and falls back to the existing `featureTitle()` description map (and its `ssXX`/`cvXX` heuristics) when `fullName()` is empty or unavailable (e.g. Glyphs 2).
- `featureListForFont()` threads the full name into the `title` attribute of each feature label — for both `ssXX` set buttons (which keep their separate set-name hover span) and ordinary feature buttons.

## Test plan

- [ ] Generate the test HTML from a font with several OT features (e.g. `smcp`, `onum`, `ss01`, a `cvXX`)
- [ ] Hover each feature button → the native tooltip shows the Glyphs full name (e.g. "Small Capitals")
- [ ] Confirm `ssXX` buttons still show their stylistic-set name on hover (the styled span) in addition to the `title`
- [ ] Confirm a feature whose `fullName()` is empty falls back to the built-in description (e.g. "Slashed Zero (zero)")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXBaror5ZdxFx577Ru3ufL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXBaror5ZdxFx577Ru3ufL)_