### PR TITLE
Fix Glyphs 4 crash in Variable Font Test HTML (and related scripts)

### DIFF
--- a/Kerning/Steal kerning from InDesign.py
+++ b/Kerning/Steal kerning from InDesign.py
@@ -297,7 +297,11 @@ class StealKerningFromInDesign(mekkaObject):
 			tempFont.instances.append(tempInstance)
 			
 			# calculate file names and paths
-			fileName = tempInstance.fileName()
+			try:
+				fileName = tempInstance.fileName()
+			except TypeError:
+				# Glyphs 4: fileName() now requires a format argument
+				fileName = tempInstance.fileName("otf")
 			filePath = os.path.join(adobeFontsFolder, fileName) # including ".otf" suffix
 			if "." in fileName:
 				fileName = fileName[:fileName.rfind(".")]

--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -6,7 +6,6 @@ Create a Test HTML for the current font inside the current Variation Font Export
 """
 
 from os import system, path
-import webbrowser
 import json
 from Cocoa import NSEvent, NSAlternateKeyMask, NSShiftKeyMask
 import codecs
@@ -301,7 +300,11 @@ def otVarSuffix():
 def otVarFileName(thisFont, thisInstance=None):
 	suffix = otVarSuffix()
 	if thisInstance is not None:
-		fileName = thisInstance.fileName()
+		try:
+			fileName = thisInstance.fileName()
+		except TypeError:
+			# Glyphs 4: fileName() now requires a format argument
+			fileName = thisInstance.fileName(suffix)
 		# circumvent bug in Glyphs 3.0.5
 		if fileName.endswith(".otf"):
 			fileName = fileName[:-4]
@@ -1653,7 +1656,9 @@ else:
 				glyphs4ShowsInFinder = Glyphs.versionNumber >= 4 and Glyphs.defaults["GSVariableExportShowInFinder"] == 1
 				if not glyphs4ShowsInFinder:
 					system(f'open "{exportPath}"')
-				webbrowser.open(f"file://{exportPath}/{htmlFileName}")
+				# webbrowser.open() can raise UnicodeEncodeError on macOS when the
+				# osascript pipe defaults to ASCII, so open the file via `open` instead:
+				system(f'open "{exportPath}/{htmlFileName}"')
 			else:
 				print("🛑 Error writing file to disk.")
 		else:

--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -136,7 +136,12 @@ def getInstanceInfo(thisFont, activeInstance, fileFormat):
 	menuName = "%s %s-%s" % (fileFormat.upper(), familyName, activeInstanceName)
 
 	# 3 approaches for determining the file names:
-	firstPartOfFileName = ".".join(activeInstance.fileName().split(".")[:-1])  # removes ".otf" at the end
+	try:
+		instanceFileName = activeInstance.fileName()
+	except TypeError:
+		# Glyphs 4: fileName() now requires a format argument
+		instanceFileName = activeInstance.fileName(fileFormat)
+	firstPartOfFileName = ".".join(instanceFileName.split(".")[:-1])  # removes ".otf" at the end
 	if not firstPartOfFileName:
 		firstPartOfFileName = activeInstance.customParameters["fileName"]
 	if not firstPartOfFileName:


### PR DESCRIPTION
## Summary

`Variable Font Test HTML.py` worked in Glyphs 3 but crashed in Glyphs 4 with:

```
__GSInstance__fileName__() missing 1 required positional argument: 'format'
```

followed by a `UnicodeEncodeError` from `webbrowser.open()`.

- In Glyphs 4, `GSInstance.fileName()` now requires a `format` argument, whereas it took none in Glyphs 3. `otVarFileName()` called it with no arguments, raising a `TypeError`. Fixed by calling `fileName()` with no args first and falling back to `fileName(suffix)` on `TypeError`, so the script still works on Glyphs 3.
- After the file was written, `webbrowser.open(f"file://{exportPath}/{htmlFileName}")` could raise a `UnicodeEncodeError` because Python's macOS `webbrowser` module pipes an AppleScript command through `osascript` using an ASCII-defaulting encoding. Replaced it with the existing `open "..."` shell command already used elsewhere in the script, which handles the path correctly and avoids the AppleScript pipe entirely.
- Applied the same `fileName()` fallback fix to two other scripts that call `GSInstance.fileName()` the same way: `Test/Webfont Test HTML.py` and `Kerning/Steal kerning from InDesign.py`.

## Test plan

- [ ] Run "Variable Font Test HTML" in Glyphs 4 on a font with variable font export settings and confirm the HTML is built and opens in the browser without errors.
- [ ] Run the same script in Glyphs 3 to confirm no regression.
- [ ] Run "Webfont Test HTML" in Glyphs 4 to confirm file name resolution still works.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGqMuxAJKPpitimAbNrdic)_