### PR TITLE
Fix emoji toolbar buttons shifting closer together after first click

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -727,6 +727,8 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 			.emojiButton {
 				cursor: pointer;
 				text-decoration: none;
+				display: inline-block;
+				padding: 0 0.3em;
 			}
 			.otFeatureLabel, .otFeature {
 				font-size: small;
@@ -1348,16 +1350,16 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 ###styleMenu###
 
 			<!-- file type -->
-				<a onclick="toggleType();" id="type" class="emojiButton" title="Switch font format (TTF/OTF, WOFF, WOFF2)">&nbsp;###TTW1W2###</a>
-				<a onclick="reloadFontFace();" id="reload" class="emojiButton" title="Reload the font from disk (Ctrl-U)">&nbsp;🔄</a>
-				<a onclick="toggleGridView();" id="gridToggle" class="emojiButton" title="Toggle grid view of all glyphs (Ctrl-G)">&nbsp;🔡&nbsp;</a>
-				<a onclick="togglePlayAll();" id="playAll" class="emojiButton" title="Animate all axes / pause (Ctrl-P)">&nbsp;▶️&nbsp;</a>
+				<a onclick="toggleType();" id="type" class="emojiButton" title="Switch font format (TTF/OTF, WOFF, WOFF2)">###TTW1W2###</a>
+				<a onclick="reloadFontFace();" id="reload" class="emojiButton" title="Reload the font from disk (Ctrl-U)">🔄</a>
+				<a onclick="toggleGridView();" id="gridToggle" class="emojiButton" title="Toggle grid view of all glyphs (Ctrl-G)">🔡</a>
+				<a onclick="togglePlayAll();" id="playAll" class="emojiButton" title="Animate all axes / pause (Ctrl-P)">▶️</a>
 
 			<!-- Samsa -->
 				%s
 
 			<!-- display type (x-ray vs. filled) -->
-				<a onclick="toggleInverse();" id="invert" class="emojiButton" title="Toggle x-ray (outline) display (Ctrl-X)">&nbsp;🔲&nbsp;</a>
+				<a onclick="toggleInverse();" id="invert" class="emojiButton" title="Toggle x-ray (outline) display (Ctrl-X)">🔲</a>
 
 			<!-- OT features -->
 				<input type="checkbox" name="kern" id="kern" value="kern" class="otFeature" onchange="updateFeatures()" checked><label for="kern" class="otFeatureLabel" title="Kerning (kern)">kern</label>
@@ -1386,7 +1388,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 """ % (samsaPlaceholder)
 
 	if shouldCreateSamsa:
-		samsaReplaceWith = "<a href='samsa-gui.html' class='emojiButton' style='color:rgb(255, 165, 0);' title='Open in Samsa font inspector'>&nbsp;🪲</a>"
+		samsaReplaceWith = "<a href='samsa-gui.html' class='emojiButton' style='color:rgb(255, 165, 0);' title='Open in Samsa font inspector'>🪲</a>"
 	else:
 		samsaReplaceWith = samsaPlaceholder
 


### PR DESCRIPTION
## Summary

- The generated HTML's toolbar buttons (type toggle, reload, grid view, play/pause, invert, Samsa) used literal `&nbsp;` characters for spacing in the initial markup, but their `onclick` handlers (`toggleType`, `toggleGridView`, `togglePlayAll`, `toggleInverse`) replace `textContent` with the bare emoji/label, dropping that padding. This made the buttons visibly snap closer together the first time each one was clicked.
- Moved the spacing into CSS (`.emojiButton { padding: 0 0.3em; display: inline-block; }`) so it no longer depends on the button's text content, and removed the now-redundant `&nbsp;` characters from the initial markup so the toolbar looks identical before and after interaction.

## Test plan

- [ ] Run "Variable Font Test HTML" in Glyphs, open the generated HTML, and confirm the toolbar button spacing stays constant before and after clicking each button (type, reload, grid, play/pause, invert).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGqMuxAJKPpitimAbNrdic)_