### PR TITLE
Fix x-ray toggle in grid view and tighten emoji toolbar spacing

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -728,7 +728,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 				cursor: pointer;
 				text-decoration: none;
 				display: inline-block;
-				padding: 0 0.3em;
+				margin: 0 .04em;
 			}
 			.otFeatureLabel, .otFeature {
 				font-size: small;
@@ -1286,13 +1286,16 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 			}
 			function toggleInverse() {
 				const testText = document.getElementById("textarea");
+				const gridview = document.getElementById("gridview");
 				if (testText) {
 					const link = document.getElementById("invert");
 					if (testText.className == "●") {
 						testText.className = "○";
+						if (gridview) gridview.className = "○";
 						link.textContent = "🔳";
 					} else {
 						testText.className = "●";
+						if (gridview) gridview.className = "●";
 						link.textContent = "🔲";
 					}
 				}


### PR DESCRIPTION
## Summary

- `toggleInverse()` only flipped the `●`/`○` class on `#textarea`, so switching to x-ray mode had no visible effect while grid view was active (`#gridview` never got the `.○` outline styling). Now the same class is applied to `#gridview` as well.
- `.emojiButton` used `padding: 0 0.3em` for spacing, which made the toolbar icons noticeably farther apart than the OT feature buttons (kern, liga, calt, ...). Switched to the same `margin: 0 .04em` used by `.otFeatureLabel`, so both button rows have matching spacing.

## Test plan

- [ ] Open the generated HTML, switch to grid view, and confirm the x-ray toggle (Ctrl-X / 🔲 button) now correctly outlines the grid glyphs.
- [ ] Confirm the emoji toolbar buttons sit as close together as the kern/liga/calt feature buttons.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGqMuxAJKPpitimAbNrdic)_