### PR TITLE
Fix ImportError: drop nonexistent TABDIDCHANGE constant

### DIFF
--- a/Paths/Bézier Fixer.py
+++ b/Paths/Bézier Fixer.py
@@ -8,7 +8,7 @@ Small floating panel combining three curve cleanup steps for the selected glyphs
 import math
 import vanilla
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSSMOOTH, GSOFFCURVE, GSCURVE, Message, UPDATEINTERFACE, TABDIDCHANGE
+from GlyphsApp import Glyphs, GSSMOOTH, GSOFFCURVE, GSCURVE, Message, UPDATEINTERFACE
 from mekkablue import mekkaObject
 
 # ---------------------------------------------------------------------------
@@ -405,7 +405,6 @@ class BezierFixer(mekkaObject):
 
 		# live preview: react to Glyphs' own selection/redraw events instead of polling
 		Glyphs.addCallback(self.updatePreview, UPDATEINTERFACE)
-		Glyphs.addCallback(self.updatePreview, TABDIDCHANGE)
 		self.w.bind("close", self.windowClose)
 		self.updatePreview()
 


### PR DESCRIPTION
## Summary

- `GlyphsApp` doesn't export a `TABDIDCHANGE` callback hook, so Bézier Fixer failed to load on Glyphs 3.5 with `ImportError: cannot import name 'TABDIDCHANGE' from 'GlyphsApp'` (reported by a user).
- Removed the import and the corresponding `Glyphs.addCallback(self.updatePreview, TABDIDCHANGE)` registration. `UPDATEINTERFACE` alone already fires on tab and selection changes, so live preview is unaffected.

## Test plan

- [ ] `python3 -m py_compile "Paths/Bézier Fixer.py"` passes.
- [ ] `flake8` reports no new issues (two pre-existing `E226` warnings unrelated to this change remain).
- [ ] Confirm in Glyphs 3.5 that the script loads without error and live preview still updates when switching tabs/glyphs.


---
_Generated by [Claude Code](https://claude.ai/code/session_014m3fXdHaAd5HPNTZPmmzTB)_