### PR TITLE
Fix beachball: don't rerun the preview pipeline on every redraw tick

### DIFF
--- a/Paths/Bézier Fixer.py
+++ b/Paths/Bézier Fixer.py
@@ -404,39 +404,48 @@ class BezierFixer(mekkaObject):
 		self.w.makeKey()
 
 		# live preview: react to Glyphs' own selection/redraw events instead of polling
-		Glyphs.addCallback(self.updatePreview, UPDATEINTERFACE)
+		Glyphs.addCallback(self.interfaceUpdated, UPDATEINTERFACE)
 		self.w.bind("close", self.windowClose)
-		self.updatePreview()
+		self.interfaceUpdated()
 
 	def windowClose(self, sender=None):
-		Glyphs.removeCallback(self.updatePreview)
+		Glyphs.removeCallback(self.interfaceUpdated)
 
 	def updateUI(self, sender=None):
 		tunnifyOn = self.pref("tunnify")
 		self.w.tunnifyStrength.enable(tunnifyOn)
 		self.w.tunnifyStrengthLabel.set(f"{int(round(self.pref('tunnifyStrength')))}%")
 
-	def updatePreview(self, sender=None):
+	def interfaceUpdated(self, sender=None):
 		"""
-		Live preview: keeps the currently active layer(s) in sync with the
-		current checkbox/slider settings. Always recomputes from a pristine
-		snapshot taken when the layer was first seen, so dragging the slider
-		or flipping a checkbox back and forth never drifts or compounds.
+		Registered as the UPDATEINTERFACE callback, which fires very
+		frequently (on almost any redraw, not just when the selection
+		changes). Stays cheap on every one of those ticks: only when the
+		watched layer(s) actually changed does it re-snapshot and re-run
+		the (comparatively expensive) preview pipeline.
 		"""
 		if self.isApplyingPreview:
 			return  # ignore redraw events triggered by our own writes below
+		font = Glyphs.font
+		layers = list(font.selectedLayers) if font else []
+		layerIDs = tuple(id(layer) for layer in layers)
+		if layerIDs == self.watchedLayerIDs:
+			return  # nothing relevant changed, don't recompute
+		self.watchedLayerIDs = layerIDs
+		self.watchedLayers = layers
+		self.snapshots = {layer: snapshotLayer(layer) for layer in layers}
+		self.applyPreview()
+
+	def applyPreview(self, sender=None):
+		"""
+		Applies the current checkbox/slider settings to the watched
+		layer(s). Always recomputes from the pristine snapshot taken when
+		the layer was first seen, so dragging the slider or flipping a
+		checkbox back and forth never drifts or compounds.
+		"""
+		if self.isApplyingPreview or not self.watchedLayers:
+			return
 		try:
-			font = Glyphs.font
-			layers = list(font.selectedLayers) if font else []
-			layerIDs = tuple(id(layer) for layer in layers)
-			if layerIDs != self.watchedLayerIDs:
-				self.watchedLayerIDs = layerIDs
-				self.watchedLayers = layers
-				self.snapshots = {layer: snapshotLayer(layer) for layer in layers}
-
-			if not self.watchedLayers:
-				return
-
 			doTunnify = self.pref("tunnify")
 			tunnifyStrength = self.pref("tunnifyStrength") / 100.0
 			doRealign = self.pref("realign")
@@ -464,7 +473,7 @@ class BezierFixer(mekkaObject):
 
 	def SavePreferences(self, sender=None):
 		super().SavePreferences(sender)
-		self.updatePreview()
+		self.applyPreview()
 
 	def BezierFixerMain(self, sender=None):
 		try:


### PR DESCRIPTION
## Summary

- Root cause of the reported beachball/hang: `UPDATEINTERFACE` fires on almost any redraw (mouse movement, cursor blink, etc.), not just on selection changes. The previous `updatePreview()` unconditionally re-ran the whole pipeline — including Tunnify's brute-force curvature search over every curve segment — on every single tick, and finished by calling `Glyphs.redraw()`, which itself triggers another `UPDATEINTERFACE` tick. That's a self-sustaining loop of expensive recomputation that pegs the main thread.
- Split the single method into:
  - `interfaceUpdated()` — the actual `UPDATEINTERFACE` callback. Only compares the currently selected layer IDs against what's already cached; returns immediately (near-zero cost) if nothing changed.
  - `applyPreview()` — the real (comparatively expensive) work: restores each watched layer from its snapshot and reapplies the current settings. Now only called when `interfaceUpdated()` detects the watched layer actually changed, or when the user changes a checkbox/slider via `SavePreferences()`.
- No behavior change from the user's perspective (still previews live), just no longer runs the expensive pipeline on every ambient redraw event.

## Test plan

- [ ] `python3 -m py_compile "Paths/Bézier Fixer.py"` passes.
- [ ] `flake8` reports no new issues (two pre-existing `E226` warnings unrelated to this change remain).
- [ ] Confirm in Glyphs.app that the panel no longer beachballs while idle or while moving the mouse over the canvas, and that live preview still updates correctly when switching glyphs or dragging the slider.


---
_Generated by [Claude Code](https://claude.ai/code/session_014m3fXdHaAd5HPNTZPmmzTB)_