### PR TITLE
Kern String Mixer: fix token evaluation error in Glyphs 3.5

### DIFF
--- a/Kerning/Kern String Mixer.py
+++ b/Kerning/Kern String Mixer.py
@@ -107,7 +107,10 @@ class KernStringMixer(mekkaObject):
 			if not font:
 				return ""
 
-		evaluatedToken = GSFeature.evaluatePredicateToken_font_error_(token, font, None)
+		if hasattr(GSFeature, "evaluatePredicateToken_font_contextLabel_error_"):
+			evaluatedToken = GSFeature.evaluatePredicateToken_font_contextLabel_error_(token, font, "", None)
+		else:
+			evaluatedToken = GSFeature.evaluatePredicateToken_font_error_(token, font, None)
 		print("Evaluation: %s\n" % evaluatedToken)
 		return evaluatedToken
 


### PR DESCRIPTION
Fixes the `AttributeError: No attribute evaluatePredicateToken_font_error_` traceback in Kern String Mixer on Glyphs 3.5 (build 3530).

Newer Glyphs builds replaced `GSFeature.evaluatePredicateToken_font_error_` with `evaluatePredicateToken_font_contextLabel_error_` (the selector BBox Bumper already uses). `expandToken()` now calls the new selector when available and falls back to the old one on older Glyphs versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzjjwZmkpH93mNXiZAzCus

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzjjwZmkpH93mNXiZAzCus)_