### PR TITLE
Put Source font first in Steal Kerning Groups UI

### DIFF
--- a/Kerning/Steal Kerning Groups from Font.py
+++ b/Kerning/Steal Kerning Groups from Font.py
@@ -50,13 +50,6 @@ class StealKerningGroupsfromFont(mekkaObject):
 		linePos += lineHeight
 
 		indent = 75
-		self.w.targetFontText = vanilla.TextBox((inset, linePos + 2, indent, 14), "Target font:", sizeStyle="small", selectable=True)
-		self.w.targetFont = vanilla.PopUpButton((inset + indent, linePos, -inset, 17), (), sizeStyle="small", callback=self.SavePreferences)
-		tooltip = "The font that receives the kerning groups."
-		self.w.targetFont.setToolTip(tooltip)
-		self.w.targetFontText.setToolTip(tooltip)
-		linePos += lineHeight
-
 		self.w.sourceFontText = vanilla.TextBox((inset, linePos + 2, indent, 14), "Source font:", sizeStyle="small", selectable=True)
 		self.w.sourceFont = vanilla.PopUpButton((inset + indent, linePos, -inset - 20, 17), (), sizeStyle="small", callback=self.SavePreferences)
 		self.w.updateButton = UpdateButton((-inset - 18, linePos - 1, -inset, 18), callback=self.updateUI)
@@ -64,6 +57,13 @@ class StealKerningGroupsfromFont(mekkaObject):
 		tooltip = "The font from which the kerning groups are taken."
 		self.w.sourceFont.setToolTip(tooltip)
 		self.w.sourceFontText.setToolTip(tooltip)
+		linePos += lineHeight
+
+		self.w.targetFontText = vanilla.TextBox((inset, linePos + 2, indent, 14), "Target font:", sizeStyle="small", selectable=True)
+		self.w.targetFont = vanilla.PopUpButton((inset + indent, linePos, -inset, 17), (), sizeStyle="small", callback=self.SavePreferences)
+		tooltip = "The font that receives the kerning groups."
+		self.w.targetFont.setToolTip(tooltip)
+		self.w.targetFontText.setToolTip(tooltip)
 		linePos += lineHeight
 
 		self.w.allGroups = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "Copy ⚠️ ALL groups (i.e., ignore selection in source font)", value=True, callback=self.SavePreferences, sizeStyle="small")


### PR DESCRIPTION
Reorders the font popups in `Kerning/Steal Kerning Groups from Font.py` so the **Source font** row comes before the **Target font** row, matching [Steal Metrics](https://github.com/mekkablue/Glyphs-Scripts/blob/master/Spacing/Steal%20Metrics.py) and the window's own description text ("Copy kerning groups from Source Font to Target Font").

This re-applies the intent of #376 by @weiweihuanghuang, which could no longer be merged after the script gained `setToolTip()` calls and the update button on the source font row. The update button stays attached to the source font row. Closes #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnDSK2CfJCtWjyJeewESiS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnDSK2CfJCtWjyJeewESiS)_