### PR TITLE
Variable Font Test HTML: fix format toggle stuck on W1/W2 for web OTVar exports

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -939,7 +939,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 
 			const sliders = document.getElementsByClassName('slider');
 			const glyphInfos = ###glyphInfos###;
-			const plainFormat = {label: "###TTW1W2###", suffix: "###plainSuffix###"};
+			const plainFormat = {label: "###plainLabel###", suffix: "###plainSuffix###"};
 
 			const animStates = {};
 			const animFreq = [0, 1/2.1, 1/1.3, 1/0.8]; // cycles/second for speeds 0-3
@@ -1402,6 +1402,9 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 		"woff2": "W2",
 	}
 	fileTypeAbbreviation = typeAppreviations[fileName.split(".")[-1]]
+	# the plain (non-web) format keeps its own label, otherwise the toggle
+	# gets stuck cycling W1/W2 when the export file itself is a woff/woff2:
+	plainLabel = typeAppreviations.get(plainSuffix, "TT")
 
 	if not defaultSize:
 		defaultSize = "40"
@@ -1433,6 +1436,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 		("###defaultSize###", defaultSize),
 		("###glyphInfos###", glyphInfos),
 		("###plainSuffix###", plainSuffix),
+		("###plainLabel###", plainLabel),
 	)
 	htmlContent = replaceSet(htmlContent, replacements)
 	return htmlContent


### PR DESCRIPTION
## Problem

The TTF/OTF ↔ WOFF ↔ WOFF2 toggle in the generated test HTML only cycled between W1 and W2 and never reached TT (or OT) anymore, even when TTF, WOFF and WOFF2 OTVars were all exported.

## Cause

`buildHTML()` filled the "plain format" label (`plainFormat.label`) from the same `###TTW1W2###` placeholder used for the toggle button's initial text, i.e. from the **exported file name's suffix**. With WOFF/WOFF2 export enabled, `otVarSuffix()` prefers `woff2`, so the plain label was baked in as `W2`. Since `toggleType()` decides the next state by comparing the button text against `plainFormat.label`, the "W2" state and the "plain" state became indistinguishable and the cycle got stuck at W1 ↔ W2.

## Fix

Introduce a separate `###plainLabel###` placeholder for `plainFormat.label`, derived from `plainSuffix` (`ttf` → TT, `otf` → OT) instead of the exported file name. The toggle button's initial text still reflects the actually loaded file, and the cycle now correctly runs e.g. W2 → TT → W1 → W2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BowXWtaaCBFtE7zHkF9fSU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BowXWtaaCBFtE7zHkF9fSU)_