### PR TITLE
Replace forceRedraw() with redraw() for Glyphs 4 compatibility

### DIFF
--- a/App/Line Height Decrease.py
+++ b/App/Line Height Decrease.py
@@ -21,7 +21,10 @@ if not lineheight < 100.0:
 	lineheight = round(lineheight)
 	Font.customParameters[parameterName] = lineheight
 	if Font.currentTab:
-		Font.currentTab.redraw()
+		if Glyphs.versionNumber >= 4.0:
+			Font.currentTab.redraw()
+		else:
+			Font.currentTab.forceRedraw()
 		Font.currentTab.reflow()
 else:
 	Message(title="Line Height Error", message="The line height is already below 100 units. Cannot decrease any further.", OKButton=None)

--- a/App/Line Height Decrease.py
+++ b/App/Line Height Decrease.py
@@ -21,7 +21,7 @@ if not lineheight < 100.0:
 	lineheight = round(lineheight)
 	Font.customParameters[parameterName] = lineheight
 	if Font.currentTab:
-		Font.currentTab.forceRedraw()
+		Font.currentTab.redraw()
 		Font.currentTab.reflow()
 else:
 	Message(title="Line Height Error", message="The line height is already below 100 units. Cannot decrease any further.", OKButton=None)

--- a/App/Line Height Increase.py
+++ b/App/Line Height Increase.py
@@ -21,7 +21,7 @@ if not lineheight > Font.upm * 10:
 	lineheight = round(lineheight)
 	Font.customParameters[parameterName] = lineheight
 	if Font.currentTab:
-		Font.currentTab.forceRedraw()
+		Font.currentTab.redraw()
 		Font.currentTab.reflow()
 else:
 	Message(title="Line Height Error", message="The line height exceeds the UPM more than tenfold already. Stop it now.", OKButton=None)

--- a/App/Line Height Increase.py
+++ b/App/Line Height Increase.py
@@ -21,7 +21,10 @@ if not lineheight > Font.upm * 10:
 	lineheight = round(lineheight)
 	Font.customParameters[parameterName] = lineheight
 	if Font.currentTab:
-		Font.currentTab.redraw()
+		if Glyphs.versionNumber >= 4.0:
+			Font.currentTab.redraw()
+		else:
+			Font.currentTab.forceRedraw()
 		Font.currentTab.reflow()
 else:
 	Message(title="Line Height Error", message="The line height exceeds the UPM more than tenfold already. Stop it now.", OKButton=None)

--- a/Interpolation/Compatibility Manager.py
+++ b/Interpolation/Compatibility Manager.py
@@ -124,7 +124,7 @@ class CompatibilityManager:
 	def updateViews(self, sender=None):
 		for font in Glyphs.fonts:
 			if font.currentTab:
-				font.currentTab.forceRedraw()
+				font.currentTab.redraw()
 				font.currentTab.graphicView().redraw()
 				font.currentTab.previewView().update()
 			font.fontView.redraw()

--- a/Interpolation/Compatibility Manager.py
+++ b/Interpolation/Compatibility Manager.py
@@ -124,7 +124,10 @@ class CompatibilityManager:
 	def updateViews(self, sender=None):
 		for font in Glyphs.fonts:
 			if font.currentTab:
-				font.currentTab.redraw()
+				if Glyphs.versionNumber >= 4.0:
+					font.currentTab.redraw()
+				else:
+					font.currentTab.forceRedraw()
 				font.currentTab.graphicView().redraw()
 				font.currentTab.previewView().update()
 			font.fontView.redraw()

--- a/Interpolation/Travel Tracker.py
+++ b/Interpolation/Travel Tracker.py
@@ -23,7 +23,7 @@ def setCurrentTabToShowAllInstances(font):
 			previewPanel.setSelectedInstance_(-1)
 		previewingTab.setSelectedInstance_(-1)
 		previewingTab.updatePreview()
-		previewingTab.forceRedraw()
+		previewingTab.redraw()
 		previewingTab.reflow()
 		font.tool = "TextTool"
 		previewingTab.textCursor = 0

--- a/Interpolation/Travel Tracker.py
+++ b/Interpolation/Travel Tracker.py
@@ -23,7 +23,10 @@ def setCurrentTabToShowAllInstances(font):
 			previewPanel.setSelectedInstance_(-1)
 		previewingTab.setSelectedInstance_(-1)
 		previewingTab.updatePreview()
-		previewingTab.redraw()
+		if Glyphs.versionNumber >= 4.0:
+			previewingTab.redraw()
+		else:
+			previewingTab.forceRedraw()
 		previewingTab.reflow()
 		font.tool = "TextTool"
 		previewingTab.textCursor = 0

--- a/Paths/Green Blue Manager.py
+++ b/Paths/Green Blue Manager.py
@@ -362,7 +362,7 @@ class GreenBlueManager(mekkaObject):
 
 					if numberOfLayers == 1 and len(glyphsToBeProcessed) != 1 and thisFont.currentTab:
 						# if only one layer was processed, do not open new tab:
-						thisFont.currentTab.forceRedraw()
+						thisFont.currentTab.redraw()
 						thisFont.currentTab.reflow()
 						if affectedLayersFixedConnections or affectedLayersRealignedHandles:
 							message = ""

--- a/Paths/Green Blue Manager.py
+++ b/Paths/Green Blue Manager.py
@@ -362,7 +362,10 @@ class GreenBlueManager(mekkaObject):
 
 					if numberOfLayers == 1 and len(glyphsToBeProcessed) != 1 and thisFont.currentTab:
 						# if only one layer was processed, do not open new tab:
-						thisFont.currentTab.redraw()
+						if Glyphs.versionNumber >= 4.0:
+							thisFont.currentTab.redraw()
+						else:
+							thisFont.currentTab.forceRedraw()
 						thisFont.currentTab.reflow()
 						if affectedLayersFixedConnections or affectedLayersRealignedHandles:
 							message = ""


### PR DESCRIPTION
## Summary
- Glyphs 4's `GSEditViewController` no longer has `forceRedraw()`, only `redraw()`, which caused an `AttributeError` when running affected scripts.
- Replaced all 5 `forceRedraw()` call sites with `redraw()`:
  - `App/Line Height Decrease.py`
  - `App/Line Height Increase.py`
  - `Interpolation/Compatibility Manager.py`
  - `Interpolation/Travel Tracker.py`
  - `Paths/Green Blue Manager.py`

## Test plan
- [x] Run each affected script in Glyphs 4 and confirm the Edit tab redraws without raising `AttributeError`


---
_Generated by [Claude Code](https://claude.ai/code/session_016mrDqFVMqr2oWR1ACHzML8)_