### PR TITLE
Add Ctrl-E shortcut to open test text in Glyphs via GlyphsApp Server

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -1148,6 +1148,8 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 						toggleGridView();
 					} else if (event.code == 'KeyP') {
 						togglePlayAll();
+					} else if (event.code == 'KeyE') {
+						openSelectionInGlyphs();
 					} else if (event.code == 'Period') {
 						styleMenu.selectedIndex = (styleMenu.selectedIndex + 1) %% styleMenuLength;
 						setStyle(styleMenu.value);
@@ -1184,6 +1186,21 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 						updateSlider();
 					}
 				}
+			}
+			function zoomForTextLength(textLength) {
+				textLength = Math.max(2, Math.min(10, textLength));
+				return 5 * textLength * textLength - 135 * textLength + 1050;
+			}
+			function openTextInGlyphs(text) {
+				// requires the GlyphsApp Server plug-in: https://github.com/mekkablue/glyphsapp-server
+				if (!text) return;
+				const zoom = zoomForTextLength(text.length);
+				fetch('http://127.0.0.1:49152/frontmostfont/newtab/?text=' + encodeURIComponent(text) + '&zoom=' + zoom).catch(function(error) {
+					console.error('Could not reach GlyphsApp Server:', error);
+				});
+			}
+			function openSelectionInGlyphs() {
+				openTextInGlyphs(window.getSelection().toString());
 			}
 			function setLanguage(lang) {
 				document.body.setAttribute('lang',lang);
@@ -1384,7 +1401,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 
 	<!-- Disclaimer -->
 	<p id="helptext" onmouseleave="vanish(this);">
-		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> play/pause all <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
+		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> play/pause all <strong>Ctrl-E</strong> selection in Glyphs <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
 	</p>
 	</body>
 </html>

--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -628,7 +628,7 @@ htmlContent = """<head>
 
 <!-- Disclaimer -->
 <p id="helptext" onmouseleave="vanish(this);">
-	Ctrl-R: Reset Charset. Ctrl-L: Latin1. Ctrl-J: LTR/RTL. Ctrl-G: cycle views. Ctrl-comma/period: step through fonts. Pull mouse across this note to make it disappear.
+	Ctrl-R: Reset Charset. Ctrl-L: Latin1. Ctrl-J: LTR/RTL. Ctrl-G: cycle views. Ctrl-E: open text in Glyphs. Ctrl-comma/period: step through fonts. Pull mouse across this note to make it disappear.
 </p>
 
 <script type="text/javascript">
@@ -651,6 +651,8 @@ htmlContent = """<head>
 				toggleLeftRight();
 			} else if (event.code == 'KeyG') {
 				cycleView();
+			} else if (event.code == 'KeyE') {
+				openTextInGlyphs(document.getElementById('textInput').value);
 			} else if (event.code == 'Period') {
 				selector.selectedIndex = (selector.selectedIndex + 1) % selectorLength;
 				changeFont();
@@ -663,6 +665,18 @@ htmlContent = """<head>
 				changeFont();
 			}
 		}
+	}
+	function zoomForTextLength(textLength) {
+		textLength = Math.max(2, Math.min(10, textLength));
+		return 5 * textLength * textLength - 135 * textLength + 1050;
+	}
+	function openTextInGlyphs(text) {
+		// requires the GlyphsApp Server plug-in: https://github.com/mekkablue/glyphsapp-server
+		if (!text) return;
+		const zoom = zoomForTextLength(text.length);
+		fetch('http://127.0.0.1:49152/frontmostfont/newtab/?text=' + encodeURIComponent(text) + '&zoom=' + zoom).catch(function(error) {
+			console.error('Could not reach GlyphsApp Server:', error);
+		});
 	}
 	function updateParagraph() {
 		// update paragraph text based on user input:


### PR DESCRIPTION
Adds a **Ctrl-E** keyboard shortcut to both test-HTML generator scripts, which opens the test text in an Edit tab of the frontmost font in Glyphs via the [GlyphsApp Server plug-in](https://github.com/mekkablue/glyphsapp-server) (`http://127.0.0.1:49152/frontmostfont/newtab/`).

- **Variable Font Test HTML**: Ctrl-E sends the *currently selected* text (does nothing when nothing is selected).
- **Webfont Test HTML**: Ctrl-E sends the current content of the text entry field.

Both pass a `zoom` query parameter computed from the text length:

```js
function zoomForTextLength(textLength) {
	textLength = Math.max(2, Math.min(10, textLength));
	return 5 * textLength * textLength - 135 * textLength + 1050;
}
```

i.e., 1–2 characters open at zoom 800, tapering down to 200 for 10 or more characters. The request is sent with `fetch()` so the test page never navigates away; if the plug-in is not installed/running, the failure is only logged to the browser console. Both help footers now mention the new shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMMCkkuNgVM4SEsqhhxc8f

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMMCkkuNgVM4SEsqhhxc8f)_