### PR TITLE
Webfont Test HTML: read Glyphs 4 export path default OTFUseExportPath

### DIFF
--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -55,9 +55,9 @@ def currentWebExportPath():
 		if Glyphs.defaults["WebfontPluginUseExportPath"]:
 			exportPath = Glyphs.defaults["WebfontPluginExportPath"]
 	else:
-		# GLYPHS 3
+		# GLYPHS 3 and 4 (Glyphs 4 renamed the key to OTFUseExportPath)
 		exportPath = Glyphs.defaults["OTFExportPathManual"]
-		if Glyphs.defaults["OTFExportUseExportPath"]:
+		if Glyphs.defaults["OTFExportUseExportPath"] or Glyphs.defaults["OTFUseExportPath"]:
 			exportPath = Glyphs.defaults["OTFExportPath"]
 	return exportPath
 


### PR DESCRIPTION
Fixes the "Could not determine export path. You need to export webfonts first." error in Glyphs 4.

Glyphs 4 renamed the use-export-path preference key from `OTFExportUseExportPath` (Glyphs 3) to `OTFUseExportPath`, so `currentWebExportPath()` never picked up `OTFExportPath` and fell back to the unset `OTFExportPathManual`. The function now checks both spellings:

```python
if Glyphs.defaults["OTFExportUseExportPath"] or Glyphs.defaults["OTFUseExportPath"]:
	exportPath = Glyphs.defaults["OTFExportPath"]
```

Variable Font Test HTML is unaffected: it reads `GSVariableExportPath` directly, which is still set in Glyphs 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMMCkkuNgVM4SEsqhhxc8f

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMMCkkuNgVM4SEsqhhxc8f)_