### PR TITLE
Rebind open-in-Glyphs shortcut to Cmd-Opt-Shift-E

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -1213,7 +1213,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 						toggleGridView();
 					} else if (event.code == 'KeyP') {
 						togglePlayAll();
-					} else if (event.code == 'KeyE') {
+					} else if (event.key == '#') {
 						openSelectionInGlyphs();
 					} else if (event.code == 'Period') {
 						styleMenu.selectedIndex = (styleMenu.selectedIndex + 1) %% styleMenuLength;
@@ -1466,7 +1466,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 
 	<!-- Disclaimer -->
 	<p id="helptext" onmouseleave="vanish(this);">
-		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> play/pause all <strong>Ctrl-E</strong> selection in Glyphs <strong>2×click</strong> grid glyph in Glyphs <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
+		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> play/pause all <strong>Ctrl-#</strong> selection in Glyphs <strong>2×click</strong> grid glyph in Glyphs <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
 	</p>
 	</body>
 </html>

--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -1194,7 +1194,9 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 				const styleMenu = document.getElementById("styleMenu");
 				const styleMenuLength = styleMenu.options.length;
 
-				if (event.ctrlKey) {
+				if (event.metaKey && event.altKey && event.shiftKey && event.code == 'KeyE') {
+					openSelectionInGlyphs();
+				} else if (event.ctrlKey) {
 					if (event.code == 'KeyR') {
 						resetParagraph();
 					} else if (event.code == 'KeyU') {
@@ -1213,8 +1215,6 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 						toggleGridView();
 					} else if (event.code == 'KeyP') {
 						togglePlayAll();
-					} else if (event.key == '#') {
-						openSelectionInGlyphs();
 					} else if (event.code == 'Period') {
 						styleMenu.selectedIndex = (styleMenu.selectedIndex + 1) %% styleMenuLength;
 						setStyle(styleMenu.value);
@@ -1466,7 +1466,7 @@ def buildHTML(fullName, fileName, unicodeEscapes, otVarSliders, variationCSS, fe
 
 	<!-- Disclaimer -->
 	<p id="helptext" onmouseleave="vanish(this);">
-		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> play/pause all <strong>Ctrl-#</strong> selection in Glyphs <strong>2×click</strong> grid glyph in Glyphs <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
+		<strong>Ctrl-period/comma</strong> step through styles <strong>Ctrl-R</strong> reset charset <strong>Ctrl-U</strong> update font <strong>Ctrl-L</strong> Lat-1 <strong>Ctrl-J</strong> LTR/RTL <strong>Ctrl-C</strong> center <strong>Ctrl-G</strong> grid view <strong>Ctrl-P</strong> play/pause all <strong>Cmd-Opt-Shift-E</strong> selection in Glyphs <strong>2×click</strong> grid glyph in Glyphs <strong>Ctrl-M</strong> toggle menu <strong>Ctrl-X</strong> x-ray <strong>Ctrl +/−</strong> size <strong>Ctrl-1/2</strong> linegap <strong>Shift</strong> high slider precision <em>Not working? Try newer macOS or <a href="https://www.google.com/chrome/">latest Chrome</a>. Hover mouse above this note to make it disappear.</em>
 	</p>
 	</body>
 </html>

--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -696,7 +696,7 @@ htmlContent = """<head>
 
 <!-- Disclaimer -->
 <p id="helptext" onmouseleave="vanish(this);">
-	Ctrl-R: Reset Charset. Ctrl-L: Latin1. Ctrl-J: LTR/RTL. Ctrl-G: cycle views. Ctrl-E: open text in Glyphs. Double-click grid glyph: open in Glyphs. Ctrl-comma/period: step through fonts. Pull mouse across this note to make it disappear.
+	Ctrl-R: Reset Charset. Ctrl-L: Latin1. Ctrl-J: LTR/RTL. Ctrl-G: cycle views. Ctrl-#: open text in Glyphs. Double-click grid glyph: open in Glyphs. Ctrl-comma/period: step through fonts. Pull mouse across this note to make it disappear.
 </p>
 
 <script type="text/javascript">
@@ -719,7 +719,7 @@ htmlContent = """<head>
 				toggleLeftRight();
 			} else if (event.code == 'KeyG') {
 				cycleView();
-			} else if (event.code == 'KeyE') {
+			} else if (event.key == '#') {
 				openTextInGlyphs(document.getElementById('textInput').value);
 			} else if (event.code == 'Period') {
 				selector.selectedIndex = (selector.selectedIndex + 1) % selectorLength;

--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -696,7 +696,7 @@ htmlContent = """<head>
 
 <!-- Disclaimer -->
 <p id="helptext" onmouseleave="vanish(this);">
-	Ctrl-R: Reset Charset. Ctrl-L: Latin1. Ctrl-J: LTR/RTL. Ctrl-G: cycle views. Ctrl-#: open text in Glyphs. Double-click grid glyph: open in Glyphs. Ctrl-comma/period: step through fonts. Pull mouse across this note to make it disappear.
+	Ctrl-R: Reset Charset. Ctrl-L: Latin1. Ctrl-J: LTR/RTL. Ctrl-G: cycle views. Cmd-Opt-Shift-E: open text in Glyphs. Double-click grid glyph: open in Glyphs. Ctrl-comma/period: step through fonts. Pull mouse across this note to make it disappear.
 </p>
 
 <script type="text/javascript">
@@ -710,7 +710,9 @@ htmlContent = """<head>
 	document.addEventListener('keyup', keyAnalysis);
 
 	function keyAnalysis(event) {
-		if (event.ctrlKey) {
+		if (event.metaKey && event.altKey && event.shiftKey && event.code == 'KeyE') {
+			openTextInGlyphs(document.getElementById('textInput').value);
+		} else if (event.ctrlKey) {
 			if (event.code == 'KeyR') {
 				setCharset();
 			} else if (event.code == 'KeyL') {
@@ -719,8 +721,6 @@ htmlContent = """<head>
 				toggleLeftRight();
 			} else if (event.code == 'KeyG') {
 				cycleView();
-			} else if (event.key == '#') {
-				openTextInGlyphs(document.getElementById('textInput').value);
 			} else if (event.code == 'Period') {
 				selector.selectedIndex = (selector.selectedIndex + 1) % selectorLength;
 				changeFont();


### PR DESCRIPTION
The `Ctrl-E` binding for "open in Glyphs" collided with Unix/Emacs line-editing (move to end of line), and `Ctrl-#` is also problematic. Since these test pages are only used on macOS, the shortcut is rebound to **Cmd-Opt-Shift-E** in both test HTMLs:

- **Variable Font Test HTML**: Cmd-Opt-Shift-E opens the current selection.
- **Webfont Test HTML**: Cmd-Opt-Shift-E opens the text-entry contents.

The check is matched via `event.metaKey && event.altKey && event.shiftKey && event.code == 'KeyE'` and moved out of the `if (event.ctrlKey)` handler chain into its own leading condition, so it no longer depends on Ctrl. Both help footers are updated accordingly. The grid double-click gesture is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMMCkkuNgVM4SEsqhhxc8f