### PR TITLE
Fix "'module' object is not callable" crash in Set Family Alignment Zones

### DIFF
--- a/Hinting/Set Family Alignment Zones.py
+++ b/Hinting/Set Family Alignment Zones.py
@@ -5,9 +5,10 @@ __doc__ = """
 Inserts Family Alignment Zones parameter with values based on an instance. Needs properly set up and compatible alignment zones in Font Info > Masters.
 """
 
+import os
 import vanilla
 from AppKit import NSFont
-from copy import deepcopy, copy
+from copy import deepcopy
 from GlyphsApp import Glyphs, Message, TTF, PLAIN, INSTANCETYPEVARIABLE
 from mekkablue import mekkaObject, UpdateButton
 from ttfautohintoptions import parameterName, valuelessOptions, availableOptionsDict, availableOptions, removeFromAutohintOptions, dictToParameterValue, ttfAutohintDict, glyphInterpolation, idotlessMeasure, writeOptionsToInstance
@@ -138,7 +139,7 @@ class SetFamilyAlignmentZones(mekkaObject):
 		# create instance & generate font
 		fileName = font.familyName.strip().replace(" ", "").lower()
 		fullPath = os.path.join(destinationFolder, fileName + ".ttf")
-		referenceInstance = copy(thisInstance)
+		referenceInstance = thisInstance.copy()
 		referenceInstance.font = font
 		referenceInstance.customParameters["fileName"] = fileName
 		referenceInstance.generate(TTF, destinationFolder, False, True, False, True, [PLAIN], True)


### PR DESCRIPTION
## Problem

Running **Set Family Alignment Zones** with the TT reference option crashed during the "Adding TT reference font" step:

```
Set Family Alignment Zones Error: 'module' object is not callable
  File "Set Family Alignment Zones.py", line 141, in addInstanceAsReferenceFontToAllTTFautohintOptions
    referenceInstance = copy(thisInstance)
TypeError: 'module' object is not callable
```

The instance was copied via the stdlib `copy()` function. In Glyphs' shared Macro-panel namespace, the `copy` name can be shadowed by the `copy` *module*, so `copy(thisInstance)` resolves to the module and is not callable.

## Fix

- Copy the reference instance with the `GSInstance.copy()` PyObjC method (`thisInstance.copy()`), matching the convention already used elsewhere in the repo (e.g. `Interpolation/Instance Cooker.py`). This removes the dependency on the shadow-prone `copy` name.
- Drop the now-unused `from copy import copy` (keeping `deepcopy`, still used for the PostScript zones).
- Add the missing `import os` — `os.path.join` was used one line above the crash and would have raised `NameError` in a clean namespace.

## Testing

- `ast.parse` confirms the file parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSTPUhTG9q718sGkXwTm3r)_