### PR TITLE
Fall back to internal name-particle values when external ones are missing

### DIFF
--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -373,11 +373,27 @@ def particleInstancesOfFont(thisFont):
 	return particleInstances
 
 
+def particleAxisValue(particle):
+	"""
+	Returns the axis value of a name particle (Glyphs 4) as a float. A particle
+	carries an internal (design space) and an external (user space) value, and
+	the external one is optional, so fall back to the internal value if it is
+	missing. Returns None if neither value is set.
+	"""
+	externalValue = particle.externalValue()
+	if externalValue is not None:
+		return float(externalValue)
+	internalValue = particle.internalValue()
+	if internalValue is not None:
+		return float(internalValue)
+	return None
+
+
 def particleStylesOfInstance(thisFont, particleInstance):
 	"""
 	Multiplies the name particles of all axes with each other, in the order of
 	the font's axes, and returns a list of (styleName, axisValues) tuples,
-	axisValues being a dict {axisTag: externalValue}. "Regular" is elidable for
+	axisValues being a dict {axisTag: axisValue}. "Regular" is elidable for
 	every axis; if all particles are elided, the instance name is the fallback.
 	"""
 	nameParticles = particleInstance.nameParticles()
@@ -398,7 +414,10 @@ def particleStylesOfInstance(thisFont, particleInstance):
 		styleName = " ".join(nameParts) if nameParts else particleInstance.name
 		axisValues = {}
 		for axisTag, particle in zip(axisTags, particleCombination):
-			axisValues[axisTag] = float(particle.externalValue())  # axis values are external values only
+			axisValue = particleAxisValue(particle)
+			if axisValue is None:
+				continue
+			axisValues[axisTag] = axisValue
 		styles.append((styleName, axisValues))
 	return styles
 
@@ -425,17 +444,20 @@ def generateAxisDict(thisFont: GSFont):
 				axisDict[axisName]["tag"] = axis.axisTag
 
 	# Glyphs 4: for axes covered by name particles (GSInstance type 4),
-	# the sliders use the external particle values only:
+	# the sliders use the particle values (external, internal as fallback):
 	for particleInstance in particleInstancesOfFont(thisFont):
 		nameParticles = particleInstance.nameParticles()
 		for axis in thisFont.axes:
 			particles = nameParticles.get(axis.axisId)
 			if not particles:
 				continue
-			externalValues = [float(particle.externalValue()) for particle in particles]
+			particleValues = [particleAxisValue(particle) for particle in particles]
+			particleValues = [value for value in particleValues if value is not None]
+			if not particleValues:
+				continue
 			axisDict[axis.name] = {
-				"min": min(externalValues),
-				"max": max(externalValues),
+				"min": min(particleValues),
+				"max": max(particleValues),
 				"tag": axis.axisTag,
 			}
 

--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -210,11 +210,27 @@ def particleInstancesOfFont(thisFont):
 	return particleInstances
 
 
+def particleAxisValue(particle):
+	"""
+	Returns the axis value of a name particle (Glyphs 4) as a float. A particle
+	carries an internal (design space) and an external (user space) value, and
+	the external one is optional, so fall back to the internal value if it is
+	missing. Returns None if neither value is set.
+	"""
+	externalValue = particle.externalValue()
+	if externalValue is not None:
+		return float(externalValue)
+	internalValue = particle.internalValue()
+	if internalValue is not None:
+		return float(internalValue)
+	return None
+
+
 def particleStylesOfInstance(thisFont, particleInstance):
 	"""
 	Multiplies the name particles of all axes with each other, in the order of
 	the font's axes, and returns a list of (styleName, axisValues) tuples,
-	axisValues being a dict {axisTag: externalValue}. "Regular" is elidable for
+	axisValues being a dict {axisTag: axisValue}. "Regular" is elidable for
 	every axis; if all particles are elided, the instance name is the fallback.
 	"""
 	nameParticles = particleInstance.nameParticles()
@@ -235,7 +251,10 @@ def particleStylesOfInstance(thisFont, particleInstance):
 		styleName = " ".join(nameParts) if nameParts else particleInstance.name
 		axisValues = {}
 		for axisTag, particle in zip(axisTags, particleCombination):
-			axisValues[axisTag] = float(particle.externalValue())
+			axisValue = particleAxisValue(particle)
+			if axisValue is None:
+				continue
+			axisValues[axisTag] = axisValue
 		styles.append((styleName, axisValues))
 	return styles
 


### PR DESCRIPTION
## Problem

Name particles (`GSNameParticle`, Glyphs 4) carry an internal design-space value and an *optional* external user-space value. Both test-HTML scripts read axis values with `float(particle.externalValue())`, which raises a `TypeError` for any particle that has no external value set:

```
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

Two reported tracebacks, same root cause:

- **Webfont Test HTML.py** — `particleStylesOfInstance()` → `float(particle.externalValue())`
- **Variable Font Test HTML.py** — `generateAxisDict()` → `[float(particle.externalValue()) for particle in particles]` (reached via `otVarInfoForFont` → `allOTVarSliders`)

`Interpolation/Insert Instances.py` already treats `externalValue` as optional when *writing* particles, so the reading side has to as well.

## Change

Added a `particleAxisValue(particle)` helper to both scripts: it prefers the external value, falls back to the internal value, and returns `None` only if neither is set.

Used it in all three call sites:

- `Test/Webfont Test HTML.py` — `particleStylesOfInstance()`; an axis with no usable value is skipped instead of crashing.
- `Test/Variable Font Test HTML.py` — `particleStylesOfInstance()`, same handling.
- `Test/Variable Font Test HTML.py` — `generateAxisDict()`; slider min/max are computed from the resolved particle values, and an axis whose particles yield no values is left to the master-derived range rather than crashing.

## Testing

Scripts compile cleanly (`py_compile`) and `flake8` reports no new findings on the changed lines. Not run inside Glyphs 4 — no app available in this environment — so a check against a font whose particles omit external values would be worth doing before release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kfm7AXUSQ8BUnMrEX587ds)_