### PR TITLE
Fix GSFontInfoValue* imports for Glyphs 4

### DIFF
--- a/Features/Stylistic Sets/Set ssXX Names.py
+++ b/Features/Stylistic Sets/Set ssXX Names.py
@@ -6,8 +6,14 @@ Prefills names for ssXX features with ‘Alternate’ or another chosen text, pl
 """
 
 import vanilla
-from GlyphsApp import Glyphs, GSFontInfoValue
+from GlyphsApp import Glyphs
 from mekkablue import mekkaObject, UpdateButton
+
+if Glyphs.versionNumber >= 4:
+	# Glyphs 4 renamed GSFontInfoValue to GSInfoValue
+	from GlyphsApp import GSInfoValue as GSFontInfoValue
+else:
+	from GlyphsApp import GSFontInfoValue
 
 
 def featureHasName(feature):

--- a/Font Info/Find and Replace in Font Info.py
+++ b/Font Info/Find and Replace in Font Info.py
@@ -8,7 +8,13 @@ Covers both general properties (names, designer, etc.) and custom parameters (st
 
 import vanilla
 import objc
-from GlyphsApp import Glyphs, GSFontInfoValueLocalized, GSFontInfoValueSingle
+from GlyphsApp import Glyphs
+
+if Glyphs.versionNumber >= 4:
+	# Glyphs 4 renamed GSFontInfoValue* to GSInfoValue*
+	from GlyphsApp import GSInfoValueLocalized as GSFontInfoValueLocalized, GSInfoValueSingle as GSFontInfoValueSingle
+else:
+	from GlyphsApp import GSFontInfoValueLocalized, GSFontInfoValueSingle
 from mekkablue import mekkaObject
 
 


### PR DESCRIPTION
Glyphs 4 renamed `GSFontInfoValue`, `GSFontInfoValueSingle` and `GSFontInfoValueLocalized` to `GSInfoValue*`, which made the old imports fail with:

```
ImportError: cannot import name 'GSFontInfoValueLocalized' from 'GlyphsApp'
```

Both affected scripts now import the new names under the old aliases when `Glyphs.versionNumber >= 4`, and keep the original imports for earlier app versions, so the rest of the code is unchanged.

- `Font Info/Find and Replace in Font Info.py` — `GSFontInfoValueSingle`, `GSFontInfoValueLocalized`
- `Features/Stylistic Sets/Set ssXX Names.py` — `GSFontInfoValue`

---
_Generated by [Claude Code](https://claude.ai/code/session_013EQ5nevCuxaL5FJGjM73SH)_