### PR TITLE
Append paths to layer.shapes instead of layer.paths

### DIFF
--- a/Build Glyphs/Build Circled Glyphs.py
+++ b/Build Glyphs/Build Circled Glyphs.py
@@ -395,7 +395,7 @@ def buildCirclePart(thisFont, glyphName, isBlack=False):
 			currentHeight = thisLayer.bounds.size.height
 			outerCircle = thisLayer.paths[0]
 			innerCircle = outerCircle.copy()
-			thisLayer.paths.append(innerCircle)
+			thisLayer.shapes.append(innerCircle)
 
 			# get stems
 			hstems = []

--- a/Build Glyphs/Build Extra Math Symbols.py
+++ b/Build Glyphs/Build Extra Math Symbols.py
@@ -297,7 +297,7 @@ try:
 			downArrowLayer = downArrow.layers[thisMaster.id]
 			downArrowLayer.clear()
 			for origPath in thisLayer.paths:
-				downArrowLayer.paths.append(origPath.copy())
+				downArrowLayer.shapes.append(origPath.copy())
 			shift = transform(shiftX=-centerOfRect(thisLayer.bounds).x, shiftY=-thisMaster.capHeight * 0.5).transformStruct()
 			rotate = transform(rotate=180).transformStruct()
 			shiftBack = transform(shiftX=downArrowLayer.width * 0.5, shiftY=thisMaster.xHeight).transformStruct()
@@ -318,9 +318,9 @@ try:
 			emptysetLayer.clear()
 			emptysetLayer.background.clear()
 			for thisPath in thisLayer.paths:
-				emptysetLayer.paths.append(thisPath.copy())
+				emptysetLayer.shapes.append(thisPath.copy())
 			for thisPath in thisLayer.background.paths:
-				emptysetLayer.background.paths.append(thisPath.copy())
+				emptysetLayer.background.shapes.append(thisPath.copy())
 
 			# scale to zero
 			zero = getZeroGlyph(thisFont).layers[thisMaster.id]

--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -84,7 +84,7 @@ def createGlyph(
 				thisLayer.clear()
 				# put paths onto the actual layer:
 				for originalPath in originalLayer.paths:
-					thisLayer.paths.append(originalPath.copy())
+					thisLayer.shapes.append(originalPath.copy())
 				# update metrics:
 				thisLayer.roundCoordinates()
 				if not setMetricsKeys:

--- a/Color Fonts/Merge All Other Masters in Current Master.py
+++ b/Color Fonts/Merge All Other Masters in Current Master.py
@@ -30,7 +30,7 @@ def process(thisGlyph):
 		sourcePaths = sourceLayer.paths
 		if sourcePaths:
 			for sourcePath in sourcePaths:
-				currentLayer.paths.append(sourcePath.copy())
+				currentLayer.shapes.append(sourcePath.copy())
 		sourceHints = sourceLayer.hints
 		if sourceHints:
 			for sourceHint in sourceLayer.hints:

--- a/Components/Convert Cap to Segment Component.py
+++ b/Components/Convert Cap to Segment Component.py
@@ -196,7 +196,7 @@ class ConvertCapToSegmentComponent(mekkaObject):
 
 				# Copy paths only (no guides, no anchors yet)
 				for path in capLayer.paths:
-					segmentLayer.paths.append(path.copy())
+					segmentLayer.shapes.append(path.copy())
 
 				# Apply the aligning transform: move startPos to origin, rotate to baseline
 				t = self.buildAlignTransform(startPos, endPos)

--- a/Kerning/kernanalysis.py
+++ b/Kerning/kernanalysis.py
@@ -367,7 +367,7 @@ def bubbleLayer(layer, offset=0):
 	bubblePath = bubbleForLayer(layer, offset=float(offset))
 	newLayer = GSLayer()
 	newLayer.width = layer.width
-	newLayer.paths.append(bubblePath)
+	newLayer.shapes.append(bubblePath)
 	return newLayer
 
 

--- a/Paths/Center Line.py
+++ b/Paths/Center Line.py
@@ -429,7 +429,7 @@ def buildRelevantLayer(path, fullLayer):
 		return fullLayer  # all paths qualify — skip the copy overhead
 	tempLayer = GSLayer()
 	for p in relevantPaths:
-		tempLayer.paths.append(copy(p))
+		tempLayer.shapes.append(copy(p))
 	return tempLayer
 
 
@@ -632,7 +632,7 @@ def cleanup(layer, threshold=40):
 		if id(layer.shapes[i]) in toRemove:
 			del layer.shapes[i]
 	for path in toAdd:
-		layer.paths.append(path)
+		layer.shapes.append(path)
 
 	# Rule 3 — snap open path ends to a collinear adjacent path end.
 	# For each open path1, collect loose ends: (innerNode, endNode) pairs for every
@@ -819,7 +819,7 @@ def createCenterLinesForSelectedSegments(layer, t=0.5, inBackground=False, selec
 				if lineOutsideShape(centerPath, layer):
 					continue
 				if not isPathAlreadyThere(centerPath, shadowLayer.paths):
-					shadowLayer.paths.append(centerPath)
+					shadowLayer.shapes.append(centerPath)
 	
 	shadowLayer.connectAllOpenPaths()
 	cleanup(layer=shadowLayer, threshold=threshold)
@@ -835,10 +835,10 @@ def createCenterLinesForSelectedSegments(layer, t=0.5, inBackground=False, selec
 	for shadowPath in shadowLayer.paths:
 		if inBackground:
 			if not isPathAlreadyThere(shadowPath, layer.background.paths):
-				layer.background.paths.append(shadowPath)
+				layer.background.shapes.append(shadowPath)
 		else:
 			if not isPathAlreadyThere(shadowPath, layer.paths):
-				layer.paths.append(shadowPath)
+				layer.shapes.append(shadowPath)
 				shadowPath.selected = True
 
 keysPressed = NSEvent.modifierFlags()

--- a/Paths/Fill Up with Rectangles.py
+++ b/Paths/Fill Up with Rectangles.py
@@ -64,11 +64,11 @@ def process(thisLayer):
 		layerRect = drawRect(bottomLeft, topRight)
 		if layerRect:
 			try:
-				# Glyphs 2:
-				thisLayer.paths.append(layerRect)
-			except:
 				# Glyphs 3:
 				thisLayer.shapes.append(layerRect)
+			except:
+				# Glyphs 2:
+				thisLayer.paths.append(layerRect)
 			return f"✅ 🔽 {bottom} ↕️ {height} ↔️ {thisLayer.width-2*inset}"
 		else:
 			return "❌ error"

--- a/Paths/Rotate around anchor.py
+++ b/Paths/Rotate around anchor.py
@@ -182,7 +182,7 @@ class Rotator(mekkaObject):
 									rotatedComp.applyTransform(RotationTransformMatrix)
 								newComps.append(rotatedComp)
 					for newPath in newPaths:
-						thisLayer.paths.append(newPath)
+						thisLayer.shapes.append(newPath)
 					for newComp in newComps:
 						thisLayer.components.append(newComp)
 


### PR DESCRIPTION
Fixes `AttributeError: 'GSProxyShapes' object has no attribute 'append'` reported for **Build Rare Symbols**, and the same latent bug in eight other scripts.

In recent Glyphs 3 versions, `layer.paths` returns a `GSProxyShapes` object that no longer supports `append()`. Paths must be appended to `layer.shapes` instead.

### Changed

Unguarded `…paths.append(…)` → `…shapes.append(…)`:

- `Build Glyphs/Build Rare Symbols.py` (the reported crash, line 87)
- `Build Glyphs/Build Circled Glyphs.py`
- `Build Glyphs/Build Extra Math Symbols.py` (3 sites, incl. `background`)
- `Color Fonts/Merge All Other Masters in Current Master.py`
- `Components/Convert Cap to Segment Component.py`
- `Kerning/kernanalysis.py`
- `Paths/Center Line.py` (5 sites, incl. `background`)
- `Paths/Rotate around anchor.py`

`Paths/Fill Up with Rectangles.py`: the `try`/`except` had the branches (and their comments) reversed — it tried `paths.append()` first and only reached `shapes.append()` via the exception. Flipped so Glyphs 3 is tried first.

### Left untouched

Occurrences that are already inside an explicit Glyphs 2 fallback branch, where `paths.append()` is the correct call: `Build Glyphs/Build Symbols.py`, `Build Glyphs/Quote Manager.py`, `Color Fonts/Convert Layerfont to CPAL+COLR Font.py`, `Pixelfonts/Flashify Pixels.py`.

`components.append()` calls were not touched — only the `paths` proxy is affected by this error.

### Verification

All changed files compile; `flake8` on them reports only pre-existing warnings untouched by this diff. Not run inside Glyphs.app.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KVGuYNJAx2tbiTRom1mKj)_