### PR TITLE
Fix Glyphs 4 proxy concatenation in Interpolation scripts

### DIFF
--- a/Interpolation/Add Grade.py
+++ b/Interpolation/Add Grade.py
@@ -345,11 +345,11 @@ class AddGrade(mekkaObject):
 			wghtAxis = font.axisForTag_("wght")
 			if wghtAxis:
 				axisID = wghtAxis.id
-				for m in font.masters + font.instances:
+				for m in (*font.masters, *font.instances):
 					value = f"wght={m.axisValueValueForId_(axisID)}"
 					if value not in weightValues:
 						weightValues.append(value)
-			for m in font.masters + font.instances:
+			for m in (*font.masters, *font.instances):
 				value = self.masterAxesString(m)
 				if value not in weightValues:
 					weightValues.append(value)

--- a/Interpolation/Axis Location Setter.py
+++ b/Interpolation/Axis Location Setter.py
@@ -107,16 +107,14 @@ class AxisLocationSetter(mekkaObject):
 	def particlesOfCurrentFont(self, sender=None):
 		particles = []
 		currentFont = Glyphs.font
-		print("CURRENT FONT", currentFont)
 		if currentFont:
-			for i in (currentFont.masters + currentFont.instances):
+			for i in (*currentFont.masters, *currentFont.instances):
 				for particle in i.name.split(" "):
 					if particle and particle not in particles:
 						particles.append(particle)
 				if i.name not in particles:
 					particles.append(i.name)
 			particles.sort()
-		print("PARTICLES", particles)
 		return particles
 
 	def axesOfCurrentFont(self, sender=None):


### PR DESCRIPTION
In Glyphs 4, `font.masters` and `font.instances` are distinct proxy types (`FontFontMasterProxy` / `FontInstancesProxy`) that can no longer be concatenated with `+`, so `Axis Location Setter` crashed on launch:

```
TypeError: unsupported operand type(s) for +: 'FontFontMasterProxy' and 'FontInstancesProxy'
```

Changed both call sites to unpack into a tuple instead — `(*font.masters, *font.instances)` — which works in Glyphs 2, 3 and 4.

- `Interpolation/Axis Location Setter.py` — `particlesOfCurrentFont()`; also removed two leftover debug `print()` calls that fired on every window open.
- `Interpolation/Add Grade.py` — `weightValuesForCurrentFont()`, same pattern in two places.

A repo-wide search turned up no other proxy concatenations. `flake8` is clean on both files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBcQoQehg8GpD56PAz9chP)_