### PR TITLE
Fix GSAnchor() positional arguments for Glyphs 4

### DIFF
--- a/Anchors/Add ZWRO origin Anchors.py
+++ b/Anchors/Add ZWRO origin Anchors.py
@@ -198,7 +198,7 @@ class AddZWROOriginAnchors(mekkaObject):
 										x = layer.bounds.origin.x
 								x += offset
 								anchorPosition = NSPoint(x, 0)
-								anchor = GSAnchor("*origin", anchorPosition)
+								anchor = GSAnchor.alloc().initWithName_position_("*origin", anchorPosition)
 								layer.anchors.append(anchor)
 								print(f"⚓️ {glyph.name}, {layer.name}: added {anchor.name} at {int(anchor.position.x)}x 0y")
 

--- a/Anchors/Add missing smart anchors.py
+++ b/Anchors/Add missing smart anchors.py
@@ -18,7 +18,7 @@ def process(glyph):
 			countOfLayers += 1
 			for i, axisName in enumerate(axisNames):
 				if not thisLayer.anchors[axisName]:
-					smartAnchor = GSAnchor(axisName, NSPoint(0, -i * 50))
+					smartAnchor = GSAnchor.alloc().initWithName_position_(axisName, NSPoint(0, -i * 50))
 					thisLayer.anchors.append(smartAnchor)
 					countOfAnchors += 1
 	print(f"  - added {countOfAnchors} anchors on {countOfLayers} smart layers.")

--- a/Anchors/Exit-Entry Manager.py
+++ b/Anchors/Exit-Entry Manager.py
@@ -256,10 +256,10 @@ class ExitEntryManager(mekkaObject):
 				glyphsProcessed += 1
 				for layer in self.getLayersFromGlyph(glyph):
 					if xEntry is not None and (not layer.anchors[entryName] or overwrite):
-						layer.anchors.append(GSAnchor(entryName, NSPoint(xEntry, 0.0)))
+						layer.anchors.append(GSAnchor.alloc().initWithName_position_(entryName, NSPoint(xEntry, 0.0)))
 						count += 1
 					if xExit is not None and (not layer.anchors[exitName] or overwrite):
-						layer.anchors.append(GSAnchor(exitName, NSPoint(xExit, 0.0)))
+						layer.anchors.append(GSAnchor.alloc().initWithName_position_(exitName, NSPoint(xExit, 0.0)))
 						count += 1
 		finally:
 			font.enableUpdateInterface()
@@ -300,23 +300,23 @@ class ExitEntryManager(mekkaObject):
 						if isInit or isMedi:
 							node = self.rightmostOncurve(layer)
 							if node and (not layer.anchors[exitName] or overwrite):
-								layer.anchors.append(GSAnchor(exitName, NSPoint(node.x, node.y)))
+								layer.anchors.append(GSAnchor.alloc().initWithName_position_(exitName, NSPoint(node.x, node.y)))
 								count += 1
 						if isMedi or isFina:
 							node = self.leftmostOncurve(layer)
 							if node and (not layer.anchors[entryName] or overwrite):
-								layer.anchors.append(GSAnchor(entryName, NSPoint(node.x, node.y)))
+								layer.anchors.append(GSAnchor.alloc().initWithName_position_(entryName, NSPoint(node.x, node.y)))
 								count += 1
 					else:
 						# RTL cursive (Arabic): exit connects to the left (x=0), entry from the right
 						if isInit or isMedi:
 							if not layer.anchors[exitName] or overwrite:
-								layer.anchors.append(GSAnchor(exitName, NSPoint(0.0, 0.0)))
+								layer.anchors.append(GSAnchor.alloc().initWithName_position_(exitName, NSPoint(0.0, 0.0)))
 								count += 1
 						if isMedi or isFina:
 							node = self.rightmostOncurve(layer)
 							if node and (not layer.anchors[entryName] or overwrite):
-								layer.anchors.append(GSAnchor(entryName, NSPoint(node.x, node.y)))
+								layer.anchors.append(GSAnchor.alloc().initWithName_position_(entryName, NSPoint(node.x, node.y)))
 								count += 1
 		finally:
 			font.enableUpdateInterface()

--- a/Anchors/Fix Arabic Anchor Order in Ligatures.py
+++ b/Anchors/Fix Arabic Anchor Order in Ligatures.py
@@ -20,7 +20,7 @@ def makeAnchor(thisLayer, anchorName, x, y):
 	thisAnchorPosition.y = y
 	thisAnchorName = anchorName
 
-	thisAnchor = GSAnchor(thisAnchorName, thisAnchorPosition)
+	thisAnchor = GSAnchor.alloc().initWithName_position_(thisAnchorName, thisAnchorPosition)
 	thisLayer.addAnchor_(thisAnchor)
 
 	print("-- %s (%.1f, %.1f)" % (thisAnchorName, thisAnchorPosition.x, thisAnchorPosition.y))

--- a/Anchors/Steal Anchors.py
+++ b/Anchors/Steal Anchors.py
@@ -219,7 +219,7 @@ class StealAnchors(mekkaObject):
 									targetLayer.anchors = None
 								for originAnchor in originLayer.anchors:
 									if not targetLayer.anchors[originAnchor.name]:
-										targetAnchor = GSAnchor(originAnchor.name, originAnchor.position)
+										targetAnchor = GSAnchor.alloc().initWithName_position_(originAnchor.name, originAnchor.position)
 										if self.pref("respectItalicAngle") and targetLayer.italicAngle != originLayer.italicAngle:
 											pivot = targetLayer.master.slantHeightForLayer_(targetLayer)
 											if not pivot:

--- a/Build Glyphs/Build Q from O and _tail.Q.py
+++ b/Build Glyphs/Build Q from O and _tail.Q.py
@@ -27,7 +27,7 @@ else:
 		# if necessary, add anchors to _tail.Q
 		if not thisLayer.anchors[newAnchorName]:
 			defaultPosition = Oglyph.layers[masterID].anchors[anchorName].position
-			newAnchor = GSAnchor(newAnchorName, defaultPosition)
+			newAnchor = GSAnchor.alloc().initWithName_position_(newAnchorName, defaultPosition)
 			thisLayer.anchors.append(newAnchor)
 
 		# rebuild Q from O:

--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -337,8 +337,8 @@ class QuoteManager(mekkaObject):
 		toRemove = [a for a in layer.anchors if a.name in ("#entry", "#exit")]
 		for a in toRemove:
 			layer.anchors.remove(a)
-		layer.anchors.append(GSAnchor("#entry", NSPoint(0, 0)))
-		layer.anchors.append(GSAnchor("#exit", NSPoint(distance, 0)))
+		layer.anchors.append(GSAnchor.alloc().initWithName_position_("#entry", NSPoint(0, 0)))
+		layer.anchors.append(GSAnchor.alloc().initWithName_position_("#exit", NSPoint(distance, 0)))
 
 	# -----------------------------------------------------------------------
 	# Metrics keys

--- a/Paths/Rotate around anchor.py
+++ b/Paths/Rotate around anchor.py
@@ -69,7 +69,7 @@ class Rotator(mekkaObject):
 			myRotationCenter = NSPoint()
 			myRotationCenter.x = int(self.pref("anchor_x"))
 			myRotationCenter.y = int(self.pref("anchor_y"))
-			myRotationAnchor = GSAnchor("#%s" % rotateAnchorName, myRotationCenter)
+			myRotationAnchor = GSAnchor.alloc().initWithName_position_("#%s" % rotateAnchorName, myRotationCenter)
 			for thisLayer in selectedLayers:
 				# adds '#rotate' if it doesn't exist, resets it if it exists:
 				thisLayer.addAnchor_(myRotationAnchor)


### PR DESCRIPTION
Glyphs 4 no longer accepts positional arguments in `GSAnchor()`:

```
TypeError: GSAnchor() does not accept positional arguments
```

This broke *Add ZWRO origin Anchors* (and every other script constructing an anchor with a name and a position). The ObjC initializer `GSAnchor.alloc().initWithName_position_(name, position)` works in Glyphs 4 as well as earlier versions, so all `GSAnchor(name, position)` call sites are switched to it.

### Files changed (14 call sites)

- `Anchors/Add ZWRO origin Anchors.py` (the reported crash)
- `Anchors/Add missing smart anchors.py`
- `Anchors/Exit-Entry Manager.py` (6 sites)
- `Anchors/Fix Arabic Anchor Order in Ligatures.py`
- `Anchors/Steal Anchors.py`
- `Build Glyphs/Build Q from O and _tail.Q.py`
- `Build Glyphs/Quote Manager.py` (2 sites)
- `Paths/Rotate around anchor.py`

Bare `GSAnchor()` calls (no arguments) are unaffected and were left as-is.

### Verification

All changed files compile (`python3 -m py_compile`). `flake8` on the changed files reports only pre-existing warnings on untouched lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHfaQ8hSVH7ozGKLztyN48)_