### PR TITLE
Insert Instances: open Font Info → Exports after inserting particles

### DIFF
--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -1166,6 +1166,13 @@ class InstanceMakerV4(mekkaObject):
 		self.SavePreferences()
 		Glyphs.clearLog()
 		insertParticlesIntoFont(thisFont, particlesDict)
+
+		# bring up Font Info → Exports so the user can see the new particles:
+		try:
+			thisFont.parent.windowController().showFontInfoWindowWithTabSelected_(2)
+		except Exception as e:
+			print(f"\n\t⚠️ Could not open Font Info → Exports: {e}")
+
 		Glyphs.showNotification("Insert Instances", "Done. Details in Macro Window.")
 
 


### PR DESCRIPTION
Follow-up to #469 and #476.

After the particles are written, the script brings up Font Info → Exports (tab index 2) via `thisFont.parent.windowController().showFontInfoWindowWithTabSelected_(2)`, so the result is visible right away. Wrapped in a try/except that reports to the Macro Window, so a font without a window controller does not abort the run.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129567bEfktd1PpmaHEqPYT)_