### PR TITLE
Work around GSControlLayer.newline() TypeError

### DIFF
--- a/Anchors/New Tab with Stray Anchors.py
+++ b/Anchors/New Tab with Stray Anchors.py
@@ -6,7 +6,7 @@ Find all anchors that are not where they are supposed to be.
 """
 
 import vanilla, sys
-from mekkablue import mekkaObject, UpdateButton, reportFontName
+from mekkablue import mekkaObject, newLineControlLayer, UpdateButton, reportFontName
 
 horizontals = (
 	"LSB",
@@ -264,11 +264,11 @@ class FindStrayAnchors(mekkaObject):
 						if not glyph:
 							continue
 						reportTab.layers.append(glyph.layers[0])
-					reportTab.layers.append(GSControlLayer.newline())
+					reportTab.layers.append(newLineControlLayer())
 					for reportedLayer in report[anchorName]:
 						reportTab.layers.append(reportedLayer)
 					for x in range(2):
-						reportTab.layers.append(GSControlLayer.newline())
+						reportTab.layers.append(newLineControlLayer())
 
 				# self.w.close() # delete if you want window to stay open
 

--- a/Build Glyphs/Center punt volat.py
+++ b/Build Glyphs/Center punt volat.py
@@ -8,6 +8,7 @@ Shifts all periodcentered.loclCAT glyphs horizontally so it fits between two Lâ€
 
 from AppKit import NSMidY, NSAffineTransform, NSEvent, NSCommandKeyMask, NSShiftKeyMask
 from GlyphsApp import Glyphs, GSControlLayer
+from mekkablue import newLineControlLayer
 
 keysPressed = NSEvent.modifierFlags()
 commandKeyPressed = (keysPressed & NSCommandKeyMask) == NSCommandKeyMask
@@ -119,7 +120,7 @@ for thisFont in theseFonts:
 					for gname in names:
 						layer = thisFont.glyphs[gname].layers[m.id]
 						theseLayers.append(layer)
-					theseLayers.append(GSControlLayer.newline())
+					theseLayers.append(newLineControlLayer())
 
 				if theseLayers:
 					if Glyphs.versionNumber >= 3:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ Negative coordinates are measured from the right/bottom edge (`-inset` = inset f
 | `match(first, second)` | Wildcard matching supporting `*` and `?` |
 | `camelCaseSplit(string)` | Splits a camelCase string into a list of words |
 | `reportTimeInNaturalLanguage(seconds)` | Formats a duration as a readable string (e.g., `"2:34 minutes"`) |
+| `newLineControlLayer()` | Returns a newline `GSControlLayer` for `tab.layers`; use instead of `GSControlLayer.newline()`, which raises a `TypeError` in some Glyphs versions |
 | `getLegibleFont(size=None)` | Returns a system legible font (Glyphs 2/3 compatible) |
 | `UpdateButton(posSize, callback, title="")` | Creates a refresh button with an NSRefreshTemplate icon |
 

--- a/Hinting/New Tabs with Glyphs Not Reaching Into Zones.py
+++ b/Hinting/New Tabs with Glyphs Not Reaching Into Zones.py
@@ -7,8 +7,8 @@ Opens a new tab with all glyphs that do NOT reach into any top or bottom alignme
 
 from collections import OrderedDict
 import vanilla
-from GlyphsApp import Glyphs, GSControlLayer
-from mekkablue import mekkaObject
+from GlyphsApp import Glyphs
+from mekkablue import mekkaObject, newLineControlLayer
 
 
 class NewTabsWithGlyphsNotReachingIntoZones(mekkaObject):
@@ -130,7 +130,7 @@ class NewTabsWithGlyphsNotReachingIntoZones(mekkaObject):
 					extraTabText = "\n\nNo %s zone:\n" % zoneType
 					for char in extraTabText:
 						if char == "\n":
-							masterTab.layers.append(GSControlLayer.newline())
+							masterTab.layers.append(newLineControlLayer())
 						else:
 							glyphName = Glyphs.niceGlyphName(char)
 							if glyphName and thisFont.glyphs[glyphName]:

--- a/Interpolation/Other/Lines by Master.py
+++ b/Interpolation/Other/Lines by Master.py
@@ -6,6 +6,7 @@ Reduplicates your edit text across masters, will add one line per master. Carefu
 """
 
 from GlyphsApp import Glyphs, GSControlLayer
+from mekkablue import newLineControlLayer
 
 thisFont = Glyphs.font
 
@@ -26,7 +27,7 @@ for m in thisFont.masters:
 		# print(layer)
 		theseLayers.append(layer)
 
-	theseLayers.append(GSControlLayer.newline())
+	theseLayers.append(newLineControlLayer())
 
 if theseLayers:
 	if glyphs3:

--- a/Interpolation/Other/masterNavigation.py
+++ b/Interpolation/Other/masterNavigation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
-from GlyphsApp import Glyphs, GSControlLayer
+from GlyphsApp import Glyphs
+from mekkablue import newLineControlLayer
 
 
 def showAllMastersOfGlyphInCurrentTab(thisGlyphName):
@@ -33,7 +34,7 @@ def showAllMastersOfGlyphs(glyphNames, openNewTab=True, avoidDuplicates=True):
 		thisGlyph = thisFont.glyphs[thisGlyphName]
 		if thisGlyph:
 			displayLayers += [layer for layer in thisGlyph.layers if layer.isMasterLayer or layer.isSpecialLayer]
-			displayLayers.append(GSControlLayer.newline())
+			displayLayers.append(newLineControlLayer())
 
 	if len(displayLayers) > 1:
 		displayLayers.pop(-1)  # remove last newline

--- a/Kerning/Compare Kerning Between Masters.py
+++ b/Kerning/Compare Kerning Between Masters.py
@@ -6,8 +6,8 @@ Report differences in kerning structures between two masters.
 """
 
 import vanilla
-from GlyphsApp import Glyphs, GSControlLayer, Message
-from mekkablue import mekkaObject, reportFontName, UpdateButton
+from GlyphsApp import Glyphs, Message
+from mekkablue import mekkaObject, newLineControlLayer, reportFontName, UpdateButton
 
 
 class CompareKerningBetweenMasters(mekkaObject):
@@ -237,7 +237,7 @@ class CompareKerningBetweenMasters(mekkaObject):
 								targetList.append(thisFont.glyphs["space"].layers[firstMaster.id])
 								targetList.append(glyphOnLSide.layers[secondMaster.id])
 								targetList.append(glyphOnRSide.layers[secondMaster.id])
-								targetList.append(GSControlLayer.newline())
+								targetList.append(newLineControlLayer())
 
 				if not missingKernCount:
 					Message(
@@ -256,7 +256,7 @@ class CompareKerningBetweenMasters(mekkaObject):
 					tab.updateKerningButton()
 
 					def addNewline():
-						tab.layers.append(GSControlLayer.newline())
+						tab.layers.append(newLineControlLayer())
 
 					def addToTab(text, masterID=firstMasterID):
 						for char in text:

--- a/Kerning/New Tab with Overkerns.py
+++ b/Kerning/New Tab with Overkerns.py
@@ -6,8 +6,8 @@ Asks a threshold percentage, and opens a new tab with all kern pairs going beyon
 """
 
 import vanilla
-from GlyphsApp import Glyphs, GSControlLayer, Message
-from mekkablue import mekkaObject, reportFontName
+from GlyphsApp import Glyphs, Message
+from mekkablue import mekkaObject, newLineControlLayer, reportFontName
 
 
 def roundedDownBy(value, base):
@@ -260,7 +260,7 @@ class NewTabwithOverkernedPairs(mekkaObject):
 										Glyphs.showMacroWindow()
 
 					if layers:
-						layers.append(GSControlLayer.newline())
+						layers.append(newLineControlLayer())
 				if layers:
 					if not (thisFont.currentTab and layers == thisFont.currentTab.layers):
 						tab = thisFont.newTab()

--- a/Paths/Path Problem Finder.py
+++ b/Paths/Path Problem Finder.py
@@ -9,11 +9,11 @@ import vanilla
 import math
 from timeit import default_timer as timer
 from AppKit import NSPoint
-from GlyphsApp import Glyphs, GSPath, GSControlLayer, GSShapeTypePath, GSLINE, GSCURVE, CURVE, GSOFFCURVE, QCURVE, Message, distance
+from GlyphsApp import Glyphs, GSPath, GSShapeTypePath, GSLINE, GSCURVE, CURVE, GSOFFCURVE, QCURVE, Message, distance
 import importlib
 import mekkablue
 importlib.reload(mekkablue)
-from mekkablue import mekkaObject, reportTimeInNaturalLanguage
+from mekkablue import mekkaObject, newLineControlLayer, reportTimeInNaturalLanguage
 
 
 canHaveOpenOutlines = (
@@ -1103,11 +1103,11 @@ class PathProblemFinder(mekkaObject):
 					layer = g.layers[masterID]
 					if layer:
 						layers.append(layer)
-			layers.append(GSControlLayer.newline())
+			layers.append(newLineControlLayer())
 			for layer in layerList:
 				layers.append(layer)
 			for i in range(2):
-				layers.append(GSControlLayer.newline())
+				layers.append(newLineControlLayer())
 
 			# report in Macro Window:
 			glyphNames = "/" + "/".join(set([layer.parent.name for layer in layerList]))

--- a/Paths/Position Clicker.py
+++ b/Paths/Position Clicker.py
@@ -7,8 +7,8 @@ Finds all combinations of positional shapes that do not click well. Clicking mea
 
 import vanilla
 from AppKit import NSFont
-from GlyphsApp import Glyphs, GSControlLayer, GSOFFCURVE, Message
-from mekkablue import mekkaObject, UpdateButton
+from GlyphsApp import Glyphs, GSOFFCURVE, Message
+from mekkablue import mekkaObject, newLineControlLayer, UpdateButton
 
 
 def layerMissesPointsAtCoordinates(thisLayer, coordinates):
@@ -231,7 +231,7 @@ class PositionClicker(mekkaObject):
 				try:
 					spaceLayer = thisFont.glyphs["space"].layers[0]
 				except:
-					spaceLayer = GSControlLayer.newline()
+					spaceLayer = newLineControlLayer()
 
 				referenceGlyph = thisFont.glyphs[referenceGlyphName]
 				try:

--- a/Spacing/Monospace Checker.py
+++ b/Spacing/Monospace Checker.py
@@ -6,8 +6,8 @@ Checks if all glyph widths in the frontmost font are actually monospaced. Report
 """
 
 import vanilla
-from GlyphsApp import Glyphs, GSControlLayer, Message
-from mekkablue import mekkaObject
+from GlyphsApp import Glyphs, Message
+from mekkablue import mekkaObject, newLineControlLayer
 
 
 class MonospaceChecker(mekkaObject):
@@ -121,7 +121,7 @@ class MonospaceChecker(mekkaObject):
 
 					# add a newline:
 					if affectedLayers:
-						newLine = GSControlLayer.newline()
+						newLine = newLineControlLayer()
 						affectedLayers.append(newLine)
 
 			if affectedLayers:

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 
 from typing import Any
 from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
-from GlyphsApp import Glyphs, GSFeature, GSClass
+from GlyphsApp import Glyphs, GSFeature, GSClass, GSControlLayer
 from vanilla import Button
 
 if Glyphs.versionNumber >= 3:
@@ -122,6 +122,21 @@ def reportFontName(font) -> str:
 	if filePath:
 		return f"{filePath.lastPathComponent()}\n📄 {filePath}"
 	return f"{font.familyName}\n⚠️ The font file has not been saved yet."
+
+
+def newLineControlLayer():
+	"""
+	Returns a GSControlLayer representing a newline, for inserting line breaks
+	into tab.layers.
+	Temporary workaround: in some Glyphs versions, GSControlLayer.newline() raises
+	'TypeError: GSControlLayer() does not accept positional arguments', because it
+	internally calls GSControlLayer(10). In that case, we fall back to the ObjC
+	initializer.
+	"""
+	try:
+		return GSControlLayer.newline()
+	except TypeError:
+		return GSControlLayer.alloc().initWithChar_(10)
 
 
 def getLegibleFont(size=None):


### PR DESCRIPTION
## Problem

In some Glyphs versions, `GSControlLayer.newline()` raises:

```
TypeError: GSControlLayer() does not accept positional arguments
```

because the wrapper internally calls `GSControlLayer(10)`, and the PyObjC `_new` machinery rejects positional arguments.

## Fix

Added `newLineControlLayer()` to the shared `mekkablue` module (`__init__.py`):

```python
try:
	return GSControlLayer.newline()
except TypeError:
	return GSControlLayer.alloc().initWithChar_(10)
```

All 13 call sites of `GSControlLayer.newline()` now use it:

- `Anchors/New Tab with Stray Anchors.py` (also fixes a missing import — `GSControlLayer` was used there without being imported)
- `Build Glyphs/Center punt volat.py`
- `Hinting/New Tabs with Glyphs Not Reaching Into Zones.py`
- `Interpolation/Other/Lines by Master.py`
- `Interpolation/Other/masterNavigation.py`
- `Kerning/Compare Kerning Between Masters.py`
- `Kerning/New Tab with Overkerns.py`
- `Paths/Path Problem Finder.py`
- `Paths/Position Clicker.py`
- `Spacing/Monospace Checker.py`

Where `GSControlLayer` was imported solely for `.newline()`, the now-unused import was dropped; where it is still used for `isinstance()` checks, it was kept.

`CLAUDE.md` documents the new helper in the shared-utilities table.

This is a temporary workaround — once `GSControlLayer.newline()` works again, the `try` branch simply succeeds and nothing else needs changing.


---
_Generated by [Claude Code](https://claude.ai/code/session_0173SRQJz39vi8ZHetsp9yys)_