### PR TITLE
Work around GSGlyph(name) TypeError

### DIFF
--- a/Build Glyphs/Build Extra Math Symbols.py
+++ b/Build Glyphs/Build Extra Math Symbols.py
@@ -5,7 +5,8 @@ __doc__ = """
 Creates lessoverequal, greateroverequal, bulletoperator, rightanglearc, righttriangle, sphericalangle, measuredangle, sunWithRays, positionIndicator, diameterSign, viewdataSquare, control.
 """
 
-from GlyphsApp import Glyphs, GSGlyph, GSComponent
+from GlyphsApp import Glyphs, GSComponent
+from mekkablue import newGlyphWithName
 from mekkablue.geometry import transform, centerOfRect
 
 thisFont = Glyphs.font  # frontmost font
@@ -65,7 +66,7 @@ def getGlyphWithName(glyphName, thisFont):
 	if thisGlyph:
 		return thisGlyph
 	else:
-		newGlyph = GSGlyph(glyphName)
+		newGlyph = newGlyphWithName(glyphName)
 		thisFont.glyphs.append(newGlyph)
 		newGlyph.updateGlyphInfo()
 		return newGlyph

--- a/Build Glyphs/Build Ldot and ldot.py
+++ b/Build Glyphs/Build Ldot and ldot.py
@@ -6,7 +6,8 @@ Builds Ldot, ldot and ldot.sc from existing L and periodcentered.loclCAT(.case/.
 """
 
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSGlyph, GSComponent
+from GlyphsApp import Glyphs, GSComponent
+from mekkablue import newGlyphWithName
 
 
 def buildLdot(targetGlyphName, baseName, accentName):
@@ -20,7 +21,7 @@ def buildLdot(targetGlyphName, baseName, accentName):
 			baseWidth = thisFont.glyphs[baseName].layers[thisMasterID].width
 			targetGlyph = thisFont.glyphs[targetGlyphName]
 			if not targetGlyph:
-				targetGlyph = GSGlyph(targetGlyphName)
+				targetGlyph = newGlyphWithName(targetGlyphName)
 				thisFont.glyphs.append(targetGlyph)
 			else:
 				targetGlyph.leftMetricsKey = None

--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -7,7 +7,7 @@ Builds white and black, small and large, circles, triangles and squares.
 
 import vanilla
 from GlyphsApp import Glyphs, GSGlyph, GSLayer, GSComponent, Message
-from mekkablue import mekkaObject
+from mekkablue import mekkaObject, newGlyphWithName
 from mekkablue.geometry import transform, offsetLayer
 
 
@@ -892,7 +892,7 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 								for newGlyphName, letters in glyphsToBuild.items():
 									newGlyph = thisFont.glyphs[newGlyphName]
 									if not newGlyph:
-										newGlyph = GSGlyph(newGlyphName)
+										newGlyph = newGlyphWithName(newGlyphName)
 										thisFont.glyphs.append(newGlyph)
 										print("🔣 %s created." % newGlyphName)
 									else:

--- a/Build Glyphs/Build Small Figures.py
+++ b/Build Glyphs/Build Small Figures.py
@@ -7,8 +7,8 @@ Takes a default set of figures (e.g., dnom), and derives the others (.numr, supe
 
 import vanilla
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSGlyph, GSComponent
-from mekkablue import mekkaObject
+from GlyphsApp import Glyphs, GSComponent
+from mekkablue import mekkaObject, newGlyphWithName
 from mekkablue.geometry import italicize
 
 
@@ -149,7 +149,7 @@ class smallFigureBuilder(mekkaObject):
 						deriveGlyphName = "%s%s" % (fig, deriveSuffix)
 						deriveGlyph = thisFont.glyphs[deriveGlyphName]
 						if not deriveGlyph:
-							deriveGlyph = GSGlyph(deriveGlyphName)
+							deriveGlyph = newGlyphWithName(deriveGlyphName)
 							thisFont.glyphs.append(deriveGlyph)
 							print(" - creating new glyph %s" % deriveGlyphName)
 							createdGlyphCount += 1

--- a/Build Glyphs/Build careof and cadauna.py
+++ b/Build Glyphs/Build careof and cadauna.py
@@ -6,7 +6,8 @@ Builds cadauna and careof from your c, u and fraction glyphs.
 """
 
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSGlyph, GSComponent
+from GlyphsApp import Glyphs, GSComponent
+from mekkablue import newGlyphWithName
 from mekkablue.geometry import transform
 
 distanceBetweenComponents = 80
@@ -93,7 +94,7 @@ def getGlyphWithName(glyphName, thisFont):
 	if thisGlyph:
 		return thisGlyph
 	else:
-		newGlyph = GSGlyph(glyphName)
+		newGlyph = newGlyphWithName(glyphName)
 		thisFont.glyphs.append(newGlyph)
 		newGlyph.updateGlyphInfo()
 		return newGlyph

--- a/Build Glyphs/Build ellipsis from period components.py
+++ b/Build Glyphs/Build ellipsis from period components.py
@@ -6,7 +6,8 @@ Inserts exit and entry anchors in the period glyph and rebuilds ellipsis with au
 """
 
 from AppKit import NSPoint, NSEvent, NSEventModifierFlagOption, NSEventModifierFlagShift
-from GlyphsApp import Glyphs, GSGlyph, GSAnchor, GSComponent, Message
+from GlyphsApp import Glyphs, GSAnchor, GSComponent, Message
+from mekkablue import newGlyphWithName
 
 Glyphs.clearLog()  # clears log in Macro window
 
@@ -44,7 +45,7 @@ if not period:
 ellipsis = thisFont.glyphs["ellipsis"]
 if not ellipsis:
 	print("⚙️ Creating ellipsis glyph (did not exist)")
-	ellipsis = GSGlyph("ellipsis")
+	ellipsis = newGlyphWithName("ellipsis")
 	thisFont.glyphs.append(ellipsis)
 
 # decomposing non-ellipsis components:

--- a/Build Glyphs/Build exclamdown and questiondown.py
+++ b/Build Glyphs/Build exclamdown and questiondown.py
@@ -6,7 +6,8 @@ Builds inverted Spanish punctuation ¡¿ for mixed and upper case. Hold down COM
 """
 
 from AppKit import NSEvent, NSEventModifierFlagShift, NSEventModifierFlagCommand
-from GlyphsApp import Glyphs, GSGlyph, GSComponent
+from GlyphsApp import Glyphs, GSComponent
+from mekkablue import newGlyphWithName
 
 invertedGlyphNames = (
 	"exclamdown",
@@ -70,7 +71,7 @@ for thisFont in theseFonts:
 				invertedGlyph = thisFont.glyphs[invertedName]
 				if not invertedGlyph:
 					print(f"   ⚙️ Creating glyph {invertedName} (did not exist)")
-					invertedGlyph = GSGlyph(invertedName)
+					invertedGlyph = newGlyphWithName(invertedName)
 					thisFont.glyphs.append(invertedGlyph)
 
 				for thisMaster in thisFont.masters:

--- a/Build Glyphs/Build rtlm Alternates.py
+++ b/Build Glyphs/Build rtlm Alternates.py
@@ -6,7 +6,8 @@ Creates horizontally mirrored composite copies for selected glyphs, and updates 
 """
 
 from AppKit import NSAffineTransform
-from GlyphsApp import Glyphs, GSGlyph, GSComponent, GSFeature
+from GlyphsApp import Glyphs, GSComponent, GSFeature
+from mekkablue import newGlyphWithName
 
 
 def flip():
@@ -68,7 +69,7 @@ try:
 			continue
 		else:
 			rtlmName = "%s.rtlm" % glyphName
-			rtlmGlyph = GSGlyph(rtlmName)
+			rtlmGlyph = newGlyphWithName(rtlmName)
 			if thisFont.glyphs[rtlmName]:
 				print("⚠️ %s: already in font, ignored.")
 			else:

--- a/Build Glyphs/Build space glyphs.py
+++ b/Build Glyphs/Build space glyphs.py
@@ -5,7 +5,8 @@ __doc__ = """
 Creates mediumspace-math, emquad, emspace, enquad, enspace, figurespace, fourperemspace, hairspace, narrownbspace, punctuationspace, sixperemspace, nbspace, thinspace, threeperemspace, zerowidthspace.
 """
 
-from GlyphsApp import Glyphs, GSGlyph
+from GlyphsApp import Glyphs
+from mekkablue import newGlyphWithName
 
 
 def tabfigure(font):
@@ -26,7 +27,7 @@ def createSpaceGlyph(thisFont, glyphName, widthKey):
 			print(u"😬 %s was set to not export. Fixed. 🙌" % glyphName)
 	else:
 		print(u"✅ Creating %s" % glyphName)
-		space = GSGlyph(glyphName)
+		space = newGlyphWithName(glyphName)
 		thisFont.glyphs.append(space)
 		created = 1
 

--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -7,8 +7,8 @@ Build and sync quotes: create single and double quotes with cursive attachment a
 
 import vanilla
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSAnchor, GSComponent, GSGlyph, GSPath, GSNode, LINE, GSMetricsTypeCapHeight
-from mekkablue import mekkaObject
+from GlyphsApp import Glyphs, GSAnchor, GSComponent, GSPath, GSNode, LINE, GSMetricsTypeCapHeight
+from mekkablue import mekkaObject, newGlyphWithName
 
 # Maps single quote → double quote
 SINGLE_TO_DOUBLE = {
@@ -319,7 +319,7 @@ class QuoteManager(mekkaObject):
 
 	def ensureGlyphExists(self, font, glyphName):
 		if not font.glyphs[glyphName]:
-			g = GSGlyph(glyphName)
+			g = newGlyphWithName(glyphName)
 			font.glyphs.append(g)
 			print(f"\t➕ Created glyph: {glyphName}")
 		return font.glyphs[glyphName]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,7 @@ Negative coordinates are measured from the right/bottom edge (`-inset` = inset f
 | `camelCaseSplit(string)` | Splits a camelCase string into a list of words |
 | `reportTimeInNaturalLanguage(seconds)` | Formats a duration as a readable string (e.g., `"2:34 minutes"`) |
 | `newLineControlLayer()` | Returns a newline `GSControlLayer` for `tab.layers`; use instead of `GSControlLayer.newline()`, which raises a `TypeError` in some Glyphs versions |
+| `newGlyphWithName(glyphName)` | Returns a new `GSGlyph` with that name; use instead of `GSGlyph(glyphName)`, which raises a `TypeError` in some Glyphs versions |
 | `getLegibleFont(size=None)` | Returns a system legible font (Glyphs 2/3 compatible) |
 | `UpdateButton(posSize, callback, title="")` | Creates a refresh button with an NSRefreshTemplate icon |
 

--- a/Components/Convert Cap to Segment Component.py
+++ b/Components/Convert Cap to Segment Component.py
@@ -13,8 +13,8 @@ import re
 
 import vanilla
 from AppKit import NSAffineTransform, NSPoint
-from GlyphsApp import CAP, SEGMENT, GSAnchor, GSGlyph, GSHint, GSLayer, Glyphs, Message
-from mekkablue import UpdateButton, mekkaObject
+from GlyphsApp import CAP, SEGMENT, GSAnchor, GSHint, GSLayer, Glyphs, Message
+from mekkablue import UpdateButton, mekkaObject, newGlyphWithName
 
 
 def sanitizeSuffix(text):
@@ -170,7 +170,7 @@ class ConvertCapToSegmentComponent(mekkaObject):
 		if font.glyphs[segmentGlyphName]:
 			del font.glyphs[segmentGlyphName]
 
-		segmentGlyph = GSGlyph(segmentGlyphName)
+		segmentGlyph = newGlyphWithName(segmentGlyphName)
 		segmentGlyph.category = "Corner"
 		segmentGlyph.export = False
 		segmentGlyph.leftMetricsKey = "=100"

--- a/Features/Stylistic Sets/Create ssXX from layer.py
+++ b/Features/Stylistic Sets/Create ssXX from layer.py
@@ -5,7 +5,8 @@ __doc__ = """
 Takes the currently opened layers and creates new glyphs with the first available .ssXX ending. It marks the new glyph blue, and (in a multiple-master file) all other, unprocessed master layers orange.
 """
 
-from GlyphsApp import Glyphs, GSGlyph
+from GlyphsApp import Glyphs
+from mekkablue import newGlyphWithName
 
 thisFont = Glyphs.font
 allGlyphNames = [x.name for x in thisFont.glyphs]
@@ -34,7 +35,7 @@ def process(sourceLayer):
 
 	# append suffix, create glyph:
 	targetGlyphName = sourceGlyphName + targetSuffix
-	targetGlyph = GSGlyph(targetGlyphName)
+	targetGlyph = newGlyphWithName(targetGlyphName)
 	thisFont.glyphs.append(targetGlyph)
 	targetGlyph.setColorIndex_(6)
 

--- a/Interpolation/Copy Layer to Layer.py
+++ b/Interpolation/Copy Layer to Layer.py
@@ -14,7 +14,7 @@ Copies one layer to another layer across selected glyphs:
 
 import vanilla
 from Foundation import NSPoint
-from mekkablue import mekkaObject, UpdateButton
+from mekkablue import mekkaObject, newGlyphWithName, UpdateButton
 
 class CopyLayerToLayer(mekkaObject):
 	prefDict = {
@@ -372,7 +372,7 @@ class CopyLayerToLayer(mekkaObject):
 				targetGlyph = targetFont.glyphs[glyphName]
 				if not targetGlyph:
 					if prefs["createIfNotPresent"]:
-						targetGlyph = GSGlyph(glyphName)
+						targetGlyph = newGlyphWithName(glyphName)
 						targetFont.glyphs.append(targetGlyph)
 						createdGlyphCount += 1
 					else:

--- a/Spacing/Tabular Figure Maker.py
+++ b/Spacing/Tabular Figure Maker.py
@@ -6,8 +6,8 @@ Takes existing .tf figures and spaces them tabularly, or creates them from exist
 """
 
 import vanilla
-from GlyphsApp import Glyphs, GSGlyph, GSComponent, Message
-from mekkablue import mekkaObject, UpdateButton, reportFontName
+from GlyphsApp import Glyphs, GSComponent, Message
+from mekkablue import mekkaObject, newGlyphWithName, UpdateButton, reportFontName
 
 
 class TabularFigureSpacer(mekkaObject):
@@ -85,7 +85,7 @@ class TabularFigureSpacer(mekkaObject):
 						niceName = Glyphs.niceGlyphName(fig)
 						figName = f"{niceName}.{self.pref('suffix').lstrip('.')}"
 						if not font.glyphs[figName]:
-							newGlyph = GSGlyph(figName)
+							newGlyph = newGlyphWithName(figName)
 							font.glyphs.append(newGlyph)
 							for layer in newGlyph.layers:
 								layer.shapes.append(GSComponent(niceName))

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 
 from typing import Any
 from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
-from GlyphsApp import Glyphs, GSFeature, GSClass, GSControlLayer
+from GlyphsApp import Glyphs, GSFeature, GSClass, GSControlLayer, GSGlyph
 from vanilla import Button
 
 if Glyphs.versionNumber >= 3:
@@ -137,6 +137,21 @@ def newLineControlLayer():
 		return GSControlLayer.newline()
 	except TypeError:
 		return GSControlLayer.alloc().initWithChar_(10)
+
+
+def newGlyphWithName(glyphName):
+	"""
+	Returns a new GSGlyph carrying the supplied name.
+	Temporary workaround: in some Glyphs versions, GSGlyph("name") raises
+	'TypeError: GSGlyph() does not accept positional arguments'. In that case,
+	we create the glyph without arguments and set its name afterwards.
+	"""
+	try:
+		return GSGlyph(glyphName)
+	except TypeError:
+		glyph = GSGlyph()
+		glyph.name = glyphName
+		return glyph
 
 
 def getLegibleFont(size=None):


### PR DESCRIPTION
## Problem

Same class of breakage as #478, this time for glyph creation:

```
⚙️ Creating ellipsis glyph (did not exist)
Traceback (most recent call last):
  File "Build ellipsis from period components.py", line 47
    ellipsis = GSGlyph("ellipsis")
TypeError: GSGlyph() does not accept positional arguments
```

## Fix

Added `newGlyphWithName()` to the shared `mekkablue` module (`__init__.py`) — create the glyph first, then set its name:

```python
try:
	return GSGlyph(glyphName)
except TypeError:
	glyph = GSGlyph()
	glyph.name = glyphName
	return glyph
```

All 14 call sites that constructed a `GSGlyph` **with a name** now use it:

- `Build Glyphs/Build Extra Math Symbols.py`
- `Build Glyphs/Build Ldot and ldot.py`
- `Build Glyphs/Build Rare Symbols.py`
- `Build Glyphs/Build Small Figures.py`
- `Build Glyphs/Build careof and cadauna.py`
- `Build Glyphs/Build ellipsis from period components.py`
- `Build Glyphs/Build exclamdown and questiondown.py`
- `Build Glyphs/Build rtlm Alternates.py`
- `Build Glyphs/Build space glyphs.py`
- `Build Glyphs/Quote Manager.py`
- `Components/Convert Cap to Segment Component.py`
- `Features/Stylistic Sets/Create ssXX from layer.py`
- `Interpolation/Copy Layer to Layer.py` (also fixes a missing import — `GSGlyph` was used there without being imported)
- `Spacing/Tabular Figure Maker.py`

Bare `GSGlyph()` calls already work and are left untouched; where `GSGlyph` was imported solely for the named form, the now-unused import was dropped.

The helper is named `newGlyphWithName` rather than `newGlyph` because several of these scripts already use `newGlyph` as a local variable name.

`CLAUDE.md` documents the helper in the shared-utilities table.

Like #478 this is self-retiring: once `GSGlyph(name)` works again, the `try` branch simply succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_0173SRQJz39vi8ZHetsp9yys)_