### PR TITLE
Fix TypeError: 'InstanceNameParticlesProxy' object is not callable

### DIFF
--- a/Interpolation/Insert Instances.py
+++ b/Interpolation/Insert Instances.py
@@ -9,7 +9,7 @@ In Glyphs 4+, presents a redesigned UI for inserting axis particles.
 from Foundation import NSDictionary, NSMutableArray, NSMutableDictionary
 import vanilla
 from GlyphsApp import Glyphs, GSInstance, INSTANCETYPESINGLE
-from mekkablue import mekkaObject, UpdateButton
+from mekkablue import mekkaObject, UpdateButton, nameParticleAxisIDs, nameParticlesForAxisID
 
 try:
 	from GlyphsApp import GSNameParticle
@@ -739,10 +739,10 @@ def insertParticlesIntoFont(font, particlesDict):
 
 	# Carry over particles of axes we are not touching:
 	allParticles = NSMutableDictionary.dictionary()
-	currentParticles = particleInstance.nameParticles()
-	if currentParticles:
-		for axisId in currentParticles:
-			allParticles.setObject_forKey_(NSMutableArray.arrayWithArray_(currentParticles[axisId]), axisId)
+	for axisId in nameParticleAxisIDs(particleInstance):
+		currentParticles = nameParticlesForAxisID(particleInstance, axisId)
+		if currentParticles:
+			allParticles.setObject_forKey_(NSMutableArray.arrayWithArray_(currentParticles), axisId)
 
 	# Build name particles for each axis:
 	for axisTag, axisData in axesData.items():

--- a/Interpolation/Instance Cooker.py
+++ b/Interpolation/Instance Cooker.py
@@ -9,7 +9,7 @@ import vanilla
 import codecs
 from AppKit import NSDictionary
 from GlyphsApp import Glyphs, GSAxis, GSCustomParameter, GSInstance, INSTANCETYPESINGLE, INSTANCETYPEVARIABLE, GetSaveFile, GetOpenFile, Message
-from mekkablue import mekkaObject, getLegibleFont
+from mekkablue import mekkaObject, getLegibleFont, nameParticlesForAxisID
 
 INSTANCETYPEPARTICLE = 4  # GSInstance.type for axis particle instances (Glyphs 4+)
 
@@ -241,13 +241,7 @@ def elidableParticleNames(font, axisId):
 	for instance in font.instances:
 		if instance.type != INSTANCETYPEPARTICLE:
 			continue
-		nameParticles = getattr(instance, "nameParticles", None)
-		if not nameParticles:
-			continue
-		try:
-			particles = nameParticles().get(axisId)
-		except:
-			continue
+		particles = nameParticlesForAxisID(instance, axisId)
 		if not particles:
 			continue
 		for particle in particles:

--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -11,6 +11,7 @@ import json
 from Cocoa import NSEvent, NSAlternateKeyMask, NSShiftKeyMask
 import codecs
 from GlyphsApp import Glyphs, GSFont, Message
+from mekkablue import nameParticlesForAxisID
 
 
 def langMenu(thisFont, indent=4):
@@ -432,11 +433,10 @@ def particleStylesOfInstance(thisFont, particleInstance):
 	axisValues being a dict {axisTag: axisValue}. "Regular" is elidable for
 	every axis; if all particles are elided, the instance name is the fallback.
 	"""
-	nameParticles = particleInstance.nameParticles()
 	axisTags = []
 	particlesPerAxis = []
 	for axis in thisFont.axes:
-		particles = nameParticles.get(axis.axisId)
+		particles = nameParticlesForAxisID(particleInstance, axis.axisId)
 		if not particles:
 			continue
 		axisTags.append(axis.axisTag)
@@ -482,9 +482,8 @@ def generateAxisDict(thisFont: GSFont):
 	# Glyphs 4: for axes covered by name particles (GSInstance type 4),
 	# the sliders use the particle values (external, internal as fallback):
 	for particleInstance in particleInstancesOfFont(thisFont):
-		nameParticles = particleInstance.nameParticles()
 		for axis in thisFont.axes:
-			particles = nameParticles.get(axis.axisId)
+			particles = nameParticlesForAxisID(particleInstance, axis.axisId)
 			if not particles:
 				continue
 			particleValues = [particleAxisValue(particle) for particle in particles]

--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -6,6 +6,7 @@ Create a Test HTML for the current font inside the current Webfont Export folder
 """
 
 from GlyphsApp import Glyphs, GSProjectDocument, INSTANCETYPESINGLE, Message
+from mekkablue import nameParticlesForAxisID
 from AppKit import NSBundle, NSClassFromString
 from os import system, path
 from itertools import product
@@ -233,11 +234,10 @@ def particleStylesOfInstance(thisFont, particleInstance):
 	axisValues being a dict {axisTag: axisValue}. "Regular" is elidable for
 	every axis; if all particles are elided, the instance name is the fallback.
 	"""
-	nameParticles = particleInstance.nameParticles()
 	axisTags = []
 	particlesPerAxis = []
 	for axis in thisFont.axes:
-		particles = nameParticles.get(axis.axisId)
+		particles = nameParticlesForAxisID(particleInstance, axis.axisId)
 		if not particles:
 			continue
 		axisTags.append(axis.axisTag)

--- a/__init__.py
+++ b/__init__.py
@@ -124,6 +124,70 @@ def reportFontName(font) -> str:
 	return f"{font.familyName}\n⚠️ The font file has not been saved yet."
 
 
+def nameParticlesOfInstance(instance):
+	"""
+	Returns the name particles of a Glyphs 4 particle instance (a mapping of
+	axisId → list of GSNameParticle), or None if the instance has none.
+	Depending on the Glyphs version, instance.nameParticles is either a pyobjc
+	method or a (dict-like) proxy object, so both are resolved here.
+	"""
+	nameParticles = getattr(instance, "nameParticles", None)
+	if callable(nameParticles):
+		try:
+			return nameParticles()
+		except TypeError:
+			pass
+	return nameParticles
+
+
+def nameParticleAxisIDs(instance):
+	"""
+	Returns a list of the axisIds for which the instance carries name particles.
+	Empty list if there are none.
+	"""
+	nameParticles = nameParticlesOfInstance(instance)
+	if not nameParticles:
+		return []
+	for accessor in ("allKeys", "keys"):
+		method = getattr(nameParticles, accessor, None)
+		if callable(method):
+			try:
+				return list(method())
+			except TypeError:
+				pass
+	try:
+		return list(nameParticles)
+	except TypeError:
+		return []
+
+
+def nameParticlesForAxisID(instance, axisID):
+	"""
+	Returns the name particles of the instance for the axis with the given
+	axisId, or None if there are none. Works with both dicts and the
+	proxy objects that Glyphs returns for instance.nameParticles.
+	"""
+	nameParticles = nameParticlesOfInstance(instance)
+	if not nameParticles:
+		return None
+	getter = getattr(nameParticles, "get", None)
+	if callable(getter):
+		try:
+			return getter(axisID)
+		except TypeError:
+			pass
+	objectForKey = getattr(nameParticles, "objectForKey_", None)
+	if objectForKey is not None:
+		try:
+			return objectForKey(axisID)
+		except TypeError:
+			pass
+	try:
+		return nameParticles[axisID]
+	except (KeyError, IndexError, TypeError):
+		return None
+
+
 def newLineControlLayer():
 	"""
 	Returns a GSControlLayer representing a newline, for inserting line breaks


### PR DESCRIPTION
## Problem

Running *Variable Font Test HTML* on a font with Glyphs 4 particle instances crashed:

```
File "Variable Font Test HTML.py", line 485, in generateAxisDict
  nameParticles = particleInstance.nameParticles()
TypeError: 'InstanceNameParticlesProxy' object is not callable
```

In current Glyphs 4 builds `instance.nameParticles` is a dict-like proxy object, not a pyobjc method, so calling it fails.

## Changes

- `__init__.py`: added three shared helpers
  - `nameParticlesOfInstance(instance)` — resolves `nameParticles` whether it is a method or a proxy
  - `nameParticleAxisIDs(instance)` — the axisIds an instance carries particles for (`allKeys`/`keys`/iteration)
  - `nameParticlesForAxisID(instance, axisID)` — particles for one axis, via `get()`, `objectForKey_()` or subscript
- `Test/Variable Font Test HTML.py`, `Test/Webfont Test HTML.py`: use `nameParticlesForAxisID()` in `particleStylesOfInstance()` and `generateAxisDict()`
- `Interpolation/Instance Cooker.py`: `elidableParticleNames()` now uses the shared helper instead of its local `nameParticles().get(...)` try/except
- `Interpolation/Insert Instances.py`: carrying over existing particles now iterates `nameParticleAxisIDs()` and reads through the helper

Behavior is unchanged where `nameParticles` is a callable method; the helpers just also cover the proxy case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XM2KsGu45zEn9pT4u7KY2i)_