### PR TITLE
Fix TypeError: 'objc.pyobjc_unicode' object is not callable on name particles

### DIFF
--- a/Interpolation/Instance Cooker.py
+++ b/Interpolation/Instance Cooker.py
@@ -9,7 +9,7 @@ import vanilla
 import codecs
 from AppKit import NSDictionary
 from GlyphsApp import Glyphs, GSAxis, GSCustomParameter, GSInstance, INSTANCETYPESINGLE, INSTANCETYPEVARIABLE, GetSaveFile, GetOpenFile, Message
-from mekkablue import mekkaObject, getLegibleFont, nameParticlesForAxisID
+from mekkablue import mekkaObject, getLegibleFont, nameParticlesForAxisID, particleName
 
 INSTANCETYPEPARTICLE = 4  # GSInstance.type for axis particle instances (Glyphs 4+)
 
@@ -254,7 +254,7 @@ def elidableParticleNames(font, axisId):
 				except:
 					continue
 				if isElidable:
-					elidableNames.add(str(particle.name()))
+					elidableNames.add(particleName(particle))
 				break
 
 	return elidableNames

--- a/Interpolation/Reproject Axis.py
+++ b/Interpolation/Reproject Axis.py
@@ -8,7 +8,7 @@ Rescale (reproject) all design-space values of an axis to a new min/max range. R
 import re
 import vanilla
 from GlyphsApp import Glyphs, Message
-from mekkablue import mekkaObject, UpdateButton
+from mekkablue import mekkaObject, UpdateButton, nameParticlesForAxisID, resolvedAttribute
 
 INSTANCETYPEPARTICLE = 4  # GSInstance.type for axis particle settings (Glyphs 4+)
 
@@ -29,38 +29,22 @@ def cleanNumber(value, forceInt=False):
 	return rounded
 
 
-def particleDictOfInstance(instance):
-	"""Return the name particle dictionary (axisID → list of GSNameParticle) of a particle-type instance, or None."""
-	for accessor in ("nameParticles", "particles", "nameParticleDict"):
-		# pyobjc method first, then the python property:
-		method = getattr(instance, "%s" % accessor, None)
-		if callable(method):
-			try:
-				value = method()
-			except TypeError:
-				value = None
-		else:
-			value = method
-		if value:
-			return value
-	return None
-
-
 def particleInternalValue(particle):
 	"""Return the internal (design space) value of a GSNameParticle, or None."""
-	internal = getattr(particle, "internal", None)
-	if callable(internal):
-		return internal()
-	return internal
+	return resolvedAttribute(particle, ("internalValue", "internal"))
 
 
 def setParticleInternalValue(particle, value):
 	"""Set the internal (design space) value of a GSNameParticle, pyobjc style where available."""
-	setter = getattr(particle, "setInternal_", None)
-	if setter is not None:
-		setter(value)
-	else:
-		particle.internal = value
+	for selectorName in ("setInternalValue_", "setInternal_"):
+		setter = getattr(particle, selectorName, None)
+		if setter is not None:
+			setter(value)
+			return
+	for attributeName in ("internalValue", "internal"):
+		if hasattr(particle, attributeName):
+			setattr(particle, attributeName, value)
+			return
 
 
 class ReprojectAxis(mekkaObject):
@@ -256,18 +240,15 @@ class ReprojectAxis(mekkaObject):
 		for instance in font.instances:
 			if instance.type != INSTANCETYPEPARTICLE:
 				continue
-			particleDict = particleDictOfInstance(instance)
-			if not particleDict:
+			particles = nameParticlesForAxisID(instance, axisID)
+			if not particles:
 				continue
-			for particleAxisID in particleDict.keys():
-				if str(particleAxisID) != str(axisID):
+			for particle in particles:
+				internalValue = particleInternalValue(particle)
+				if internalValue is None:
 					continue
-				for particle in particleDict[particleAxisID]:
-					internalValue = particleInternalValue(particle)
-					if internalValue is None:
-						continue
-					setParticleInternalValue(particle, cleanNumber(reproject(float(internalValue)), forceInt=roundValues))
-					count += 1
+				setParticleInternalValue(particle, cleanNumber(reproject(float(internalValue)), forceInt=roundValues))
+				count += 1
 		return count
 
 	def ReprojectAxisMain(self, sender=None):

--- a/Test/Variable Font Test HTML.py
+++ b/Test/Variable Font Test HTML.py
@@ -11,7 +11,7 @@ import json
 from Cocoa import NSEvent, NSAlternateKeyMask, NSShiftKeyMask
 import codecs
 from GlyphsApp import Glyphs, GSFont, Message
-from mekkablue import nameParticlesForAxisID
+from mekkablue import nameParticlesForAxisID, particleAxisValue, particleName
 
 
 def langMenu(thisFont, indent=4):
@@ -410,22 +410,6 @@ def particleInstancesOfFont(thisFont):
 	return particleInstances
 
 
-def particleAxisValue(particle):
-	"""
-	Returns the axis value of a name particle (Glyphs 4) as a float. A particle
-	carries an internal (design space) and an external (user space) value, and
-	the external one is optional, so fall back to the internal value if it is
-	missing. Returns None if neither value is set.
-	"""
-	externalValue = particle.externalValue()
-	if externalValue is not None:
-		return float(externalValue)
-	internalValue = particle.internalValue()
-	if internalValue is not None:
-		return float(internalValue)
-	return None
-
-
 def particleStylesOfInstance(thisFont, particleInstance):
 	"""
 	Multiplies the name particles of all axes with each other, in the order of
@@ -446,7 +430,7 @@ def particleStylesOfInstance(thisFont, particleInstance):
 
 	styles = []
 	for particleCombination in product(*particlesPerAxis):
-		nameParts = [particle.name() for particle in particleCombination if particle.name() != "Regular"]
+		nameParts = [particleName(particle) for particle in particleCombination if particleName(particle) != "Regular"]
 		styleName = " ".join(nameParts) if nameParts else particleInstance.name
 		axisValues = {}
 		for axisTag, particle in zip(axisTags, particleCombination):

--- a/Test/Webfont Test HTML.py
+++ b/Test/Webfont Test HTML.py
@@ -6,7 +6,7 @@ Create a Test HTML for the current font inside the current Webfont Export folder
 """
 
 from GlyphsApp import Glyphs, GSProjectDocument, INSTANCETYPESINGLE, Message
-from mekkablue import nameParticlesForAxisID
+from mekkablue import nameParticlesForAxisID, particleAxisValue, particleName
 from AppKit import NSBundle, NSClassFromString
 from os import system, path
 from itertools import product
@@ -211,22 +211,6 @@ def particleInstancesOfFont(thisFont):
 	return particleInstances
 
 
-def particleAxisValue(particle):
-	"""
-	Returns the axis value of a name particle (Glyphs 4) as a float. A particle
-	carries an internal (design space) and an external (user space) value, and
-	the external one is optional, so fall back to the internal value if it is
-	missing. Returns None if neither value is set.
-	"""
-	externalValue = particle.externalValue()
-	if externalValue is not None:
-		return float(externalValue)
-	internalValue = particle.internalValue()
-	if internalValue is not None:
-		return float(internalValue)
-	return None
-
-
 def particleStylesOfInstance(thisFont, particleInstance):
 	"""
 	Multiplies the name particles of all axes with each other, in the order of
@@ -247,7 +231,7 @@ def particleStylesOfInstance(thisFont, particleInstance):
 
 	styles = []
 	for particleCombination in product(*particlesPerAxis):
-		nameParts = [particle.name() for particle in particleCombination if particle.name() != "Regular"]
+		nameParts = [particleName(particle) for particle in particleCombination if particleName(particle) != "Regular"]
 		styleName = " ".join(nameParts) if nameParts else particleInstance.name
 		axisValues = {}
 		for axisTag, particle in zip(axisTags, particleCombination):

--- a/__init__.py
+++ b/__init__.py
@@ -124,6 +124,51 @@ def reportFontName(font) -> str:
 	return f"{font.familyName}\n⚠️ The font file has not been saved yet."
 
 
+def resolvedAttribute(obj, attributeNames, default=None):
+	"""
+	Returns the value of the first of attributeNames that the object has.
+	Depending on the Glyphs version, the same information is exposed either as a
+	pyobjc method or as a plain python property, so both are resolved here.
+	attributeNames can be a single name or a tuple of names to try in order.
+	"""
+	if isinstance(attributeNames, str):
+		attributeNames = (attributeNames, )
+	for attributeName in attributeNames:
+		value = getattr(obj, attributeName, None)
+		if value is None:
+			continue
+		if callable(value):
+			try:
+				value = value()
+			except TypeError:
+				pass
+		if value is not None:
+			return value
+	return default
+
+
+def particleName(particle):
+	"""Returns the name of a GSNameParticle (Glyphs 4) as a string, empty string if it has none."""
+	return str(resolvedAttribute(particle, "name", ""))
+
+
+def particleAxisValue(particle):
+	"""
+	Returns the axis value of a GSNameParticle (Glyphs 4) as a float. A particle
+	carries an internal (design space) and an external (user space) value, and
+	the external one is optional, so fall back to the internal value if it is
+	missing. Returns None if neither value is set.
+	"""
+	for attributeNames in (("externalValue", "external"), ("internalValue", "internal")):
+		value = resolvedAttribute(particle, attributeNames)
+		if value is not None:
+			try:
+				return float(value)
+			except (TypeError, ValueError):
+				pass
+	return None
+
+
 def nameParticlesOfInstance(instance):
 	"""
 	Returns the name particles of a Glyphs 4 particle instance (a mapping of


### PR DESCRIPTION
## Problem

Follow-up to #480. With the `nameParticles` proxy handled, *Variable Font Test HTML* now crashes one level deeper:

```
File "Variable Font Test HTML.py", line 449, in particleStylesOfInstance
  nameParts = [particle.name() for particle in particleCombination if particle.name() != "Regular"]
TypeError: 'objc.pyobjc_unicode' object is not callable
```

`GSNameParticle.name` (and `externalValue` / `internalValue`) are plain properties in current Glyphs 4 builds, not pyobjc methods.

## Changes

- `__init__.py`: added `resolvedAttribute(obj, attributeNames, default=None)`, which returns the value of the first matching attribute whether it is a method or a property, plus two particle accessors built on it:
  - `particleName(particle)` — the particle name as a string
  - `particleAxisValue(particle)` — external value, falling back to internal value
- `Test/Variable Font Test HTML.py`, `Test/Webfont Test HTML.py`: dropped their local `particleAxisValue()` copies and use the shared helpers
- `Interpolation/Instance Cooker.py`: `elidableParticleNames()` uses `particleName()`
- `Interpolation/Reproject Axis.py`: dropped its own `particleDictOfInstance()` / `particleInternalValue()` in favor of the shared helpers. This also fixes a latent bug there: it only looked for an `internal` attribute, while the attribute is `internalValue` (cf. the `setInternalValue_` setter used in *Insert Instances*), so particle reprojection silently did nothing. The setter now tries `setInternalValue_` before `setInternal_`.

## Verification

Compiled all touched files, and exercised the helpers against method-style, property-style, dict and proxy stubs (including a proxy without `.get()`): names, axis values and per-axis lookups resolve correctly in every shape, and a missing key returns `None`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XM2KsGu45zEn9pT4u7KY2i)_