### PR TITLE
Build Rare Symbols: survive roundCoordinates() exception

### DIFF
--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -9,6 +9,34 @@ import vanilla
 from GlyphsApp import Glyphs, GSGlyph, GSLayer, GSComponent, Message
 from mekkablue import mekkaObject, newGlyphWithName
 from mekkablue.geometry import transform, offsetLayer
+from Foundation import NSPoint
+
+
+def roundLayerCoordinates(thisLayer):
+	"""
+	Rounds all coordinates of the layer to integer values.
+	Uses layer.roundCoordinates() where available, and falls back to rounding
+	node, anchor and width values one by one, because roundCoordinates() throws
+	an NSInvalidArgumentException on some layer types in some app versions.
+	"""
+	try:
+		thisLayer.roundCoordinates()
+		return
+	except Exception:
+		pass
+
+	for thisPath in thisLayer.paths:
+		for thisNode in thisPath.nodes:
+			thisNode.position = NSPoint(round(thisNode.position.x), round(thisNode.position.y))
+	for thisAnchor in thisLayer.anchors:
+		try:
+			thisAnchor.position = NSPoint(round(thisAnchor.position.x), round(thisAnchor.position.y))
+		except Exception:
+			pass
+	try:
+		thisLayer.width = round(thisLayer.width)
+	except Exception:
+		pass
 
 
 def createGlyph(
@@ -86,7 +114,7 @@ def createGlyph(
 				for originalPath in originalLayer.paths:
 					thisLayer.shapes.append(originalPath.copy())
 				# update metrics:
-				thisLayer.roundCoordinates()
+				roundLayerCoordinates(thisLayer)
 				if not setMetricsKeys:
 					if thisLayer.italicAngle == 0.0:
 						thisLayer.leftMetricsKey = "==%i" % sidebearing


### PR DESCRIPTION
`GSLayer.roundCoordinates()` raises

```
NSInvalidArgumentException - *** -[NSProxy doesNotRecognizeSelector:setPosition:forLayerWidth:] called!
```

on some layer types (reported while building into a variable font with intermediate layers like `SRFF:0, sl:-14`). Because the call sits in the middle of `createGlyph()`, the exception aborted the whole build run after the first few glyphs.

Added a `roundLayerCoordinates()` helper that calls `layer.roundCoordinates()` and, if that throws, rounds node positions, anchor positions and the layer width one by one instead. `createGlyph()` now uses the helper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm5i1NNx7fxxEaLcjnxw5r)_