### PR TITLE
Lines by Master: fix AttributeError on TabLayersProxy

### DIFF
--- a/Interpolation/Other/Lines by Master.py
+++ b/Interpolation/Other/Lines by Master.py
@@ -9,7 +9,6 @@ from GlyphsApp import Glyphs, GSControlLayer
 
 thisFont = Glyphs.font
 
-glyphs3 = Glyphs.versionNumber >= 3
 cutoff = []
 names = []
 for i, l in enumerate(thisFont.currentTab.layers):
@@ -29,8 +28,6 @@ for m in thisFont.masters:
 	theseLayers.append(GSControlLayer.newline())
 
 if theseLayers:
-	if glyphs3:
-		thisFont.currentTab.layers.extend(theseLayers)
-	else:
-		for layer in theseLayers:
-			thisFont.currentTab.layers.append(layer)
+	thisTab = thisFont.currentTab
+	# TabLayersProxy has no extend(), so rebuild the whole list in one go:
+	thisTab.layers = list(thisTab.layers) + theseLayers


### PR DESCRIPTION
TabLayersProxy has no extend(), so the script crashed with AttributeError as soon as it tried to add the generated lines to the current tab. Replace the extend()/append() version branch with a single full-list assignment, which the proxy does support, and drop the now-unused glyphs3 flag.