### PR TITLE
Compensate for button bezel drawn outside the frame, rearrange Build Rare Symbols footer

### DIFF
--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -7,7 +7,7 @@ Builds white and black, small and large, circles, triangles and squares.
 
 import vanilla
 from GlyphsApp import Glyphs, GSGlyph, GSLayer, GSComponent, Message
-from mekkablue import alignButtonsRight, mekkaObject, newGlyphWithName
+from mekkablue import alignButtons, mekkaObject, newGlyphWithName
 from mekkablue.geometry import transform, offsetLayer
 from Foundation import NSPoint
 
@@ -494,7 +494,14 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 		self.w.uncheckAllButton.setToolTip("Deactivates all checkboxes above the separator line.")
 
 		# fit the button row to the button metrics of the running macOS version:
-		alignButtonsRight(self.w, (self.w.uncheckAllButton, self.w.checkAllButton, self.w.runButton), inset=inset)
+		# Build in the bottom right corner, the (un)check buttons in the bottom left:
+		alignButtons(
+			self.w,
+			rightButtons=(self.w.runButton, ),
+			leftButtons=(self.w.uncheckAllButton, self.w.checkAllButton),
+			inset=inset,
+			leftGap=6,
+		)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/__init__.py
+++ b/__init__.py
@@ -283,34 +283,73 @@ def UpdateButton(posSize, callback, title=""):
 	return button
 
 
-def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
+def measureButtons(buttons, minButtonWidth=70, minHeight=20):
 	"""
-	Lays out a row of vanilla Buttons right-aligned along the bottom edge of window.
-	Each button gets the width and height it actually needs on the running system,
-	rather than a hardcoded size. Necessary because push buttons became wider and
-	taller in recent macOS versions, which made hardcoded button rows overlap.
+	Measures the sizes vanilla Buttons need on the running system.
+	Returns (widths, height): a list with one width per button, and the height
+	of the tallest one. Sizes are taken from the button cells, so they follow
+	the button metrics of the macOS version the script is running on.
+	"""
+	widths = []
+	height = minHeight
+	for button in buttons:
+		nsButton = button.getNSButton()
+		nsButton.sizeToFit()
+		sizes = [nsButton.fittingSize(), nsButton.frame().size]
+		try:
+			sizes.append(nsButton.cell().cellSize())
+			sizes.append(nsButton.intrinsicContentSize())
+		except:
+			pass
+		widths.append(max(minButtonWidth, ceil(max(size.width for size in sizes))))
+		height = max(height, ceil(max(size.height for size in sizes)))
+	return widths, height
+
+
+def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, leftGap=None, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
+	"""
+	Lays out one or two groups of vanilla Buttons along the bottom edge of window:
+	rightButtons are right-aligned, leftButtons are left-aligned. Each button gets
+	the size it actually needs on the running system, rather than a hardcoded one.
+	Necessary because push buttons became larger in recent macOS versions, which
+	made hardcoded button rows collide.
+	Recent macOS also draws the button bezel *beyond* the button frame. The overhang
+	is derived from how much taller the buttons are than assumedHeight, and added to
+	the gaps and the window edge distances, so that the drawn (not the theoretical)
+	buttons keep their distances. On older macOS, the overhang is zero and the layout
+	is the same as before.
 	window: the vanilla window containing the buttons,
-	buttons: the vanilla Buttons, in left-to-right order,
-	inset: distance to the right and bottom window edges,
-	gap: horizontal distance between two buttons,
+	rightButtons: the vanilla Buttons for the bottom right, in left-to-right order,
+	leftButtons: the vanilla Buttons for the bottom left, in left-to-right order,
+	inset: distance to the window edges,
+	gap: visible horizontal distance between two buttons,
+	leftGap: same, but for the leftButtons group only; defaults to gap,
 	minButtonWidth: no button will be narrower than this,
 	assumedHeight: the button height the rest of the window layout was built for,
 	resizeWindow: if True, grows the window (and its size constraints) to fit the row.
 	Returns (rowWidth, rowHeight), or None if the measurement failed.
 	"""
 	try:
-		widths = []
-		height = assumedHeight
-		for button in buttons:
-			nsButton = button.getNSButton()
-			nsButton.sizeToFit()
-			fittingSize = nsButton.fittingSize()
-			frameSize = nsButton.frame().size
-			widths.append(max(minButtonWidth, ceil(max(fittingSize.width, frameSize.width))))
-			height = max(height, ceil(max(fittingSize.height, frameSize.height)))
+		if leftGap is None:
+			leftGap = gap
+		rightWidths, height = measureButtons(rightButtons, minButtonWidth, assumedHeight)
+		leftWidths, height = measureButtons(leftButtons, minButtonWidth, height)
 
-		rowWidth = sum(widths) + gap * (len(buttons) - 1)
-		rowHeight = height
+		# how far the drawn bezel extends beyond the button frame on each side:
+		overhang = max(0, (height - assumedHeight) // 2)
+		bottomInset = inset + overhang
+		sideInset = inset + overhang
+		rightStep = gap + 2 * overhang  # frame distance yielding a visible distance of gap
+		leftStep = leftGap + 2 * overhang
+
+		rowWidth = sum(rightWidths) + sum(leftWidths) + 2 * overhang
+		if rightWidths:
+			rowWidth += rightStep * (len(rightWidths) - 1)
+		if leftWidths:
+			rowWidth += leftStep * (len(leftWidths) - 1)
+		if rightWidths and leftWidths:
+			rowWidth += rightStep  # minimum distance between the two groups
+		rowHeight = height + 2 * overhang
 
 		if resizeWindow:
 			windowWidth, windowHeight = window.getPosSize()[2], window.getPosSize()[3]
@@ -326,11 +365,17 @@ def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assu
 					setter(NSMakeSize(currentSize.width + deltaWidth, currentSize.height + deltaHeight))
 				window.resize(windowWidth + deltaWidth, windowHeight + deltaHeight, animate=False)
 
-		# position right to left:
-		rightEdge = inset
-		for button, width in zip(reversed(buttons), reversed(widths)):
-			button.setPosSize((-rightEdge - width, -rowHeight - inset, width, rowHeight))
-			rightEdge += width + gap
+		# right group, positioned right to left:
+		rightEdge = sideInset
+		for button, width in zip(reversed(rightButtons), reversed(rightWidths)):
+			button.setPosSize((-rightEdge - width, -height - bottomInset, width, height))
+			rightEdge += width + rightStep
+
+		# left group, positioned left to right:
+		leftEdge = sideInset
+		for button, width in zip(leftButtons, leftWidths):
+			button.setPosSize((leftEdge, -height - bottomInset, width, height))
+			leftEdge += width + leftStep
 
 		return rowWidth, rowHeight
 	except:
@@ -338,6 +383,22 @@ def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assu
 		print(traceback.format_exc())
 		print("⚠️ Could not align buttons, will resort to their original positions.")
 		return None
+
+
+def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
+	"""
+	Lays out a row of vanilla Buttons right-aligned along the bottom edge of window.
+	Shortcut for alignButtons() with a right group only; see there for details.
+	"""
+	return alignButtons(
+		window,
+		rightButtons=buttons,
+		inset=inset,
+		gap=gap,
+		minButtonWidth=minButtonWidth,
+		assumedHeight=assumedHeight,
+		resizeWindow=resizeWindow,
+	)
 
 
 def updatedCode(oldCode, beginSig, endSig, newCode):


### PR DESCRIPTION
Follow-up to #485, which reduced but did not remove the button crowding.

## What was still wrong

Measuring the buttons was only half the problem. Recent macOS draws the push button bezel *beyond* the button frame, roughly 5–6pt per side. So even with correctly measured frames laid out with a 10pt gap, the drawn buttons still ended up flush against each other — the layout gap is entirely eaten by the two overhangs.

## Fix

`alignButtons()` now estimates that overhang from how much taller the measured buttons are than the height the window layout assumed (`(height - assumedHeight) // 2` — the capsule grows roughly uniformly), and then:

- uses `gap + 2 × overhang` as the *frame* distance, so the *visible* distance is the requested gap;
- insets the outer frames by the overhang, so the drawn edges — not the theoretical ones — sit `inset` from the window edges;
- grows the window by the drawn row height rather than the frame height.

On older macOS the measured height equals `assumedHeight`, the overhang is 0, and the computed positions are identical to the old hardcoded ones.

Also split measurement into `measureButtons()`, which now additionally consults `cell().cellSize()` and `intrinsicContentSize()` and takes the largest estimate.

## Build Rare Symbols footer

`alignButtons()` takes an optional group of left-aligned buttons, so the footer can be split:

```python
alignButtons(
    self.w,
    rightButtons=(self.w.runButton, ),
    leftButtons=(self.w.uncheckAllButton, self.w.checkAllButton),
    inset=inset,
    leftGap=6,
)
```

Uncheck All / Check All now sit in the bottom left with a tighter 6pt gap, Build alone in the bottom right corner. `alignButtonsRight()` stays as a shortcut and is still what `Build Symbols.py` uses.

## Testing

Verified against a stub of the AppKit/vanilla API that simulates a 6pt bezel overhang: visible gaps come out at exactly 10pt (right group) and 6pt (left pair), all drawn margins at 15pt, and the old-metrics case reproduces the original positions with no window growth. The rendering still needs a look inside Glyphs on the affected macOS version — in particular whether the estimated overhang matches the real one.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dKKjpeixqJgHZDjesF4g7)_