### PR TITLE
Fix overlapping bottom buttons on macOS 26 by using Auto Layout

### DIFF
--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -7,7 +7,7 @@ Builds white and black, small and large, circles, triangles and squares.
 
 import vanilla
 from GlyphsApp import Glyphs, GSGlyph, GSLayer, GSComponent, Message
-from mekkablue import alignButtonsRight, mekkaObject, newGlyphWithName
+from mekkablue import mekkaObject, newGlyphWithName
 from mekkablue.geometry import transform, offsetLayer
 from Foundation import NSPoint
 
@@ -492,9 +492,6 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 		self.w.checkAllButton.setToolTip("Activates all checkboxes above the separator line.")
 		self.w.uncheckAllButton = vanilla.Button((-300 - inset, -20 - inset, -190 - inset, -inset), "Uncheck All", callback=self.checkOrUncheckAll)
 		self.w.uncheckAllButton.setToolTip("Deactivates all checkboxes above the separator line.")
-
-		# fit the button row to the button metrics of the running macOS version:
-		alignButtonsRight(self.w, (self.w.uncheckAllButton, self.w.checkAllButton, self.w.runButton), inset=inset)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -10,6 +10,7 @@ from GlyphsApp import Glyphs, GSGlyph, GSLayer, GSComponent, Message
 from mekkablue import mekkaObject, newGlyphWithName
 from mekkablue.geometry import transform, offsetLayer
 from Foundation import NSPoint
+from AppKit import NSLayoutConstraintOrientationHorizontal, NSLayoutPriorityDefaultHigh, NSLayoutPriorityRequired, NSLayoutConstraintOrientationVertical, NSLayoutPriorityWindowSizeStayPut
 
 
 def roundLayerCoordinates(thisLayer):
@@ -394,7 +395,7 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 	def __init__(self):
 		# Window 'self.w':
 		windowWidth = 355
-		windowHeight = 328
+		windowHeight = 1  # Auto Layout grows the window to the required size
 		self.w = vanilla.FloatingWindow(
 			(windowWidth, windowHeight),  # default window size
 			"Build Rare Symbols",  # window title
@@ -402,86 +403,72 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 		)
 
 		# UI elements:
-		linePos, inset, lineHeight = 12, 15, 22
-		column = 170
+		inset = 15
 
-		self.w.descriptionText = vanilla.TextBox((inset, linePos + 2, -inset, 14), "Build the following glyphs, see tooltips for details:", sizeStyle='small', selectable=True)
-		linePos += lineHeight
+		self.w.descriptionText = vanilla.TextBox("auto", "Build the following glyphs, see tooltips for details:", sizeStyle='small', selectable=True)
 
-		self.w.whiteTriangles = vanilla.CheckBox((inset + 2, linePos - 1, column, 20), "White Triangles △▷▽◁", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.whiteTriangles = vanilla.CheckBox("auto", "White Triangles \u25b3\u25b7\u25bd\u25c1", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.whiteTriangles.setToolTip("Will create upWhiteTriangle, rightWhiteTriangle, downWhiteTriangle, leftWhiteTriangle.")
-		self.w.blackTriangles = vanilla.CheckBox((inset + column, linePos - 1, -inset, 20), "Black Triangles ▲▶▼◀", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.blackTriangles = vanilla.CheckBox("auto", "Black Triangles \u25b2\u25b6\u25bc\u25c0", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.blackTriangles.setToolTip("Will create upBlackTriangle, rightBlackTriangle, downBlackTriangle, leftBlackTriangle.")
-		linePos += lineHeight
 
-		self.w.blackArrowheads = vanilla.CheckBox((inset + 2, linePos - 1, column, 20), "Black Arrowheads", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.blackArrowheads = vanilla.CheckBox("auto", "Black Arrowheads", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.blackArrowheads.setToolTip("Will create blackUpEquilateralArrowhead, blackRightEquilateralArrowhead, blackDownEquilateralArrowhead, blackLeftEquilateralArrowhead.")
-		self.w.black3DArrowheads = vanilla.CheckBox((inset + column, linePos - 1, -inset, 20), "Black 3D Arrowheads", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.black3DArrowheads = vanilla.CheckBox("auto", "Black 3D Arrowheads", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.black3DArrowheads.setToolTip("Will create threeDRightLightedUpEquilateralArrowhead, threeDTopLightedRightEquilateralArrowhead, threeDLeftLightedDownEquilateralArrowhead, threeDTopLightedLeftEquilateralArrowhead.")
-		linePos += lineHeight
 
-		self.w.whiteShapes = vanilla.CheckBox((inset + 2, linePos - 1, column, 20), "White Shapes ○◇□", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.whiteShapes = vanilla.CheckBox("auto", "White Shapes \u25cb\u25c7\u25a1", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.whiteShapes.setToolTip("Will create whiteCircle, whiteDiamond, whiteSquare.")
-		self.w.blackShapes = vanilla.CheckBox((inset + column, linePos - 1, -inset, 20), "Black Shapes ●◆■", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.blackShapes = vanilla.CheckBox("auto", "Black Shapes \u25cf\u25c6\u25a0", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.blackShapes.setToolTip("Will create blackCircle, blackDiamond, blackSquare.")
-		linePos += lineHeight
 
-		self.w.whiteLargeSquare = vanilla.CheckBox((inset + 2, linePos - 1, column, 20), "White Large Square ⬜", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.whiteLargeSquare = vanilla.CheckBox("auto", "White Large Square \u2b1c", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.whiteLargeSquare.setToolTip("Will create whiteLargeSquare.")
-		self.w.blackLargeSquare = vanilla.CheckBox((inset + column, linePos - 1, -inset, 20), "Black Large Square ⬛", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.blackLargeSquare = vanilla.CheckBox("auto", "Black Large Square \u2b1b", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.blackLargeSquare.setToolTip("Will create blackLargeSquare.")
-		linePos += lineHeight
 
-		self.w.propellor = vanilla.CheckBox((inset + 2, linePos - 1, column, 20), "Cmd Opt Shift ⌘⌥⇧", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.propellor = vanilla.CheckBox("auto", "Cmd Opt Shift \u2318\u2325\u21e7", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.propellor.setToolTip("Will create propellor, optionKey, upWhiteArrow.")
-		self.w.viewdataSquare = vanilla.CheckBox((inset + column, linePos - 1, -inset, 20), "Viewdata Square ⌗", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.viewdataSquare = vanilla.CheckBox("auto", "Viewdata Square \u2317", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.viewdataSquare.setToolTip("Will create viewdataSquare.")
-		linePos += lineHeight
 
-		self.w.servicemarkTel = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "SM and TEL ℠℡", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.servicemarkTel = vanilla.CheckBox("auto", "SM and TEL \u2120\u2121", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.servicemarkTel.setToolTip("Will create servicemark, telephone. Requires M and trademark glyphs in the font.")
-		linePos += lineHeight
 
-		self.w.line = vanilla.HorizontalLine((inset, linePos + 2, -inset, 1))
-		linePos += 12
+		self.w.line = vanilla.HorizontalLine("auto")
 
-		self.w.strokeText = vanilla.TextBox((inset, linePos + 2, 80, 14), "Stroke width:", sizeStyle='small', selectable=True)
-		self.w.stroke = vanilla.EditText((inset + 80, linePos - 1, 70, 19), "50", callback=self.SavePreferences, sizeStyle='small')
-		tooltip = "Uniform stroke width for icons. Does not apply to filled (‘black’) shapes."
+		self.w.strokeText = vanilla.TextBox("auto", "Stroke width:", sizeStyle='small', selectable=True)
+		self.w.stroke = vanilla.EditText("auto", "50", callback=self.SavePreferences, sizeStyle='small')
+		tooltip = "Uniform stroke width for icons. Does not apply to filled (\u2018black\u2019) shapes."
 		self.w.strokeText.setToolTip(tooltip)
 		self.w.stroke.setToolTip(tooltip)
-		self.w.heightText = vanilla.TextBox((inset + column, linePos + 2, 85, 14), "Symbol size:", sizeStyle='small', selectable=True)
-		self.w.height = vanilla.EditText((inset + column + 85, linePos - 1, -inset, 19), "700", callback=self.SavePreferences, sizeStyle='small')
-		tooltip = "Reference height for symbols. Each symbol has an individual scale factor. This reference height times the symbol’s scale factor will yield the actual size of each symbol."
+		self.w.heightText = vanilla.TextBox("auto", "Symbol size:", sizeStyle='small', selectable=True)
+		self.w.height = vanilla.EditText("auto", "700", callback=self.SavePreferences, sizeStyle='small')
+		tooltip = "Reference height for symbols. Each symbol has an individual scale factor. This reference height times the symbol\u2019s scale factor will yield the actual size of each symbol."
 		self.w.heightText.setToolTip(tooltip)
 		self.w.height.setToolTip(tooltip)
-		linePos += lineHeight
 
-		self.w.sidebearingText = vanilla.TextBox((inset, linePos + 2, 80, 14), "Sidebearings:", sizeStyle='small', selectable=True)
-		self.w.sidebearing = vanilla.EditText((inset + 80, linePos - 1, 70, 19), "50", callback=self.SavePreferences, sizeStyle='small')
-		tooltip = "Will be used for both LSB and RSB, effectively centering the shape in its width. Unless the Disrespect Italic Angle option is used, will insert it as metrics keys (e.g., LSB ‘=60’, RSB ‘=|’) for the glyph."
+		self.w.sidebearingText = vanilla.TextBox("auto", "Sidebearings:", sizeStyle='small', selectable=True)
+		self.w.sidebearing = vanilla.EditText("auto", "50", callback=self.SavePreferences, sizeStyle='small')
+		tooltip = "Will be used for both LSB and RSB, effectively centering the shape in its width. Unless the Disrespect Italic Angle option is used, will insert it as metrics keys (e.g., LSB \u201860\u2019, RSB \u2018=|\u2019) for the glyph."
 		self.w.sidebearingText.setToolTip(tooltip)
 		self.w.sidebearing.setToolTip(tooltip)
-		self.w.belowBaseText = vanilla.TextBox((inset + column, linePos + 2, 85, 14), "% below base:", sizeStyle='small', selectable=True)
-		self.w.belowBase = vanilla.EditText((inset + column + 85, linePos - 1, -inset, 19), "10", callback=self.SavePreferences, sizeStyle='small')
+		self.w.belowBaseText = vanilla.TextBox("auto", "% below base:", sizeStyle='small', selectable=True)
+		self.w.belowBase = vanilla.EditText("auto", "10", callback=self.SavePreferences, sizeStyle='small')
 		tooltip = "Determines the vertical position. This percentage of the symbol size will be below, the rest above the baseline."
 		self.w.belowBaseText.setToolTip(tooltip)
 		self.w.belowBase.setToolTip(tooltip)
-		linePos += lineHeight
 
-		self.w.disrespectItalicAngle = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "Sidebearings disrespect italic angle (useful for italics)", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.disrespectItalicAngle = vanilla.CheckBox("auto", "Sidebearings disrespect italic angle (useful for italics)", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.disrespectItalicAngle.setToolTip("If activated, will not set sidebearing metrics keys if there is an italic angle other than zero. If the italic angle is zero, will set (and update) layer-specific metrics keys (with double equals sign ==). Highly recommended if you want the symbols to have the same widths in upright and italic.")
-		linePos += lineHeight
 
-		self.w.overwriteExistingGlyphs = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "⚠️ Overwrite existing glyphs", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.overwriteExistingGlyphs = vanilla.CheckBox("auto", "\u26a0\ufe0f Overwrite existing glyphs", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.overwriteExistingGlyphs.setToolTip("If set, will simply replace the symbol glyphs that already exist. Careful with this option if you made any manual changes you want to keep.")
-		linePos += lineHeight
 
-		self.w.openTab = vanilla.CheckBox((inset + 2, linePos - 1, column, 20), "Open tab with new glyphs", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.openTab = vanilla.CheckBox("auto", "Open tab with new glyphs", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.openTab.setToolTip("If set, will open a new Edit tab containing all the glyphs for which a checkbox is set further above.")
-		self.w.reuseTab = vanilla.CheckBox((inset + column, linePos - 1, -inset, 20), "Reuse current tab", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.reuseTab = vanilla.CheckBox("auto", "Reuse current tab", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.reuseTab.setToolTip("If set, will reuse the frontmost Edit tab, rather than open a new one. Only opens a new tab if no Edit tab is active.")
-		linePos += lineHeight
 
 		# Run Button:
 		self.w.runButton = vanilla.Button("auto", "Build", callback=self.BuildCirclesSquaresTrianglesMain)
@@ -492,14 +479,68 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 		self.w.checkAllButton.setToolTip("Activates all checkboxes above the separator line.")
 		self.w.uncheckAllButton = vanilla.Button("auto", "Uncheck All", callback=self.checkOrUncheckAll)
 		self.w.uncheckAllButton.setToolTip("Deactivates all checkboxes above the separator line.")
+
+		# the field labels hug their text, so the fields get the leftover width:
+		for label in (self.w.strokeText, self.w.heightText, self.w.sidebearingText, self.w.belowBaseText):
+			nsLabel = label.getNSTextField()
+			nsLabel.setContentHuggingPriority_forOrientation_(NSLayoutPriorityDefaultHigh, NSLayoutConstraintOrientationHorizontal)
+			nsLabel.setContentCompressionResistancePriority_forOrientation_(NSLayoutPriorityRequired, NSLayoutConstraintOrientationHorizontal)
+
+		# one shared width per column, so the two columns line up throughout the window:
+		gridCheckBoxes = (
+			self.w.whiteTriangles, self.w.blackArrowheads, self.w.whiteShapes, self.w.whiteLargeSquare, self.w.propellor, self.w.openTab,
+			self.w.blackTriangles, self.w.black3DArrowheads, self.w.blackShapes, self.w.blackLargeSquare, self.w.viewdataSquare, self.w.reuseTab,
+		)
+		labelColumn = (self.w.strokeText, self.w.sidebearingText)
+		rightLabelColumn = (self.w.heightText, self.w.belowBaseText)
+		# all four number fields share one width, so neither column swallows the slack:
+		fieldColumn = (self.w.stroke, self.w.sidebearing, self.w.height, self.w.belowBase)
+		columnRules = [
+			{"view1": cell, "attribute1": "width", "view2": gridCheckBoxes[0], "attribute2": "width"}
+			for cell in gridCheckBoxes[1:]
+		] + [
+			{"view1": cell, "attribute1": "width", "view2": column[0], "attribute2": "width"}
+			for column in (labelColumn, rightLabelColumn, fieldColumn)
+			for cell in column[1:]
+		]
+
+		# checkboxes and square buttons do not resist vertical stretching by default; with
+		# every control hugging vertically and no flexible gap in the chain, the window ends
+		# up exactly as tall as Auto Layout needs. NSLayoutPriorityWindowSizeStayPut (500) is
+		# the level at which a constraint starts outranking "keep the window size".
+		for view in self.w.getNSWindow().contentView().subviews():
+			view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+
 		self.w.addAutoPosSizeRules(
 			[
-				"H:[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"H:|-inset-[descriptionText]-inset-|",
+				"H:|-inset-[whiteTriangles]-gap-[blackTriangles]-(>=inset)-|",
+				"H:|-inset-[blackArrowheads]-gap-[black3DArrowheads]-(>=inset)-|",
+				"H:|-inset-[whiteShapes]-gap-[blackShapes]-(>=inset)-|",
+				"H:|-inset-[whiteLargeSquare]-gap-[blackLargeSquare]-(>=inset)-|",
+				"H:|-inset-[propellor]-gap-[viewdataSquare]-(>=inset)-|",
+				"H:|-inset-[servicemarkTel]-(>=inset)-|",
+				"H:|-inset-[line]-inset-|",
+				"H:|-inset-[strokeText]-gap-[stroke]-gap-[heightText]-gap-[height]-inset-|",
+				"H:|-inset-[sidebearingText]-gap-[sidebearing]-gap-[belowBaseText]-gap-[belowBase]-inset-|",
+				"H:|-inset-[disrespectItalicAngle]-(>=inset)-|",
+				"H:|-inset-[overwriteExistingGlyphs]-(>=inset)-|",
+				"H:|-inset-[openTab]-gap-[reuseTab]-(>=inset)-|",
+				"H:|-(>=inset)-[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				# one vertical chain per column; equal row heights keep the rows aligned
+				"V:|-gap-[descriptionText]-row-[whiteTriangles]-row-[blackArrowheads]-row-[whiteShapes]-row-[whiteLargeSquare]-row-[propellor]-row-[servicemarkTel]-gap-[line(1)]-gap-[stroke]-row-[sidebearing]-row-[disrespectItalicAngle]-row-[overwriteExistingGlyphs]-row-[openTab]-inset-[runButton]-inset-|",
+				"V:[descriptionText]-row-[blackTriangles]-row-[black3DArrowheads]-row-[blackShapes]-row-[blackLargeSquare]-row-[viewdataSquare]",
 				"V:[uncheckAllButton]-inset-|",
 				"V:[checkAllButton]-inset-|",
-				"V:[runButton]-inset-|",
-			],
-			metrics={"inset": inset, "gap": 10},
+				{"view1": self.w.height, "attribute1": "centerY", "view2": self.w.stroke, "attribute2": "centerY"},
+				{"view1": self.w.belowBase, "attribute1": "centerY", "view2": self.w.sidebearing, "attribute2": "centerY"},
+				{"view1": self.w.strokeText, "attribute1": "centerY", "view2": self.w.stroke, "attribute2": "centerY"},
+				{"view1": self.w.heightText, "attribute1": "centerY", "view2": self.w.stroke, "attribute2": "centerY"},
+				{"view1": self.w.sidebearingText, "attribute1": "centerY", "view2": self.w.sidebearing, "attribute2": "centerY"},
+				{"view1": self.w.belowBaseText, "attribute1": "centerY", "view2": self.w.sidebearing, "attribute2": "centerY"},
+				{"view1": self.w.reuseTab, "attribute1": "centerY", "view2": self.w.openTab, "attribute2": "centerY"},
+			] + columnRules,
+			metrics={"inset": inset, "gap": 8, "row": 8},
 		)
 
 		# Load Settings:

--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -7,7 +7,7 @@ Builds white and black, small and large, circles, triangles and squares.
 
 import vanilla
 from GlyphsApp import Glyphs, GSGlyph, GSLayer, GSComponent, Message
-from mekkablue import alignButtons, mekkaObject, newGlyphWithName
+from mekkablue import alignButtonsRight, mekkaObject, newGlyphWithName
 from mekkablue.geometry import transform, offsetLayer
 from Foundation import NSPoint
 
@@ -494,14 +494,7 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 		self.w.uncheckAllButton.setToolTip("Deactivates all checkboxes above the separator line.")
 
 		# fit the button row to the button metrics of the running macOS version:
-		# Build in the bottom right corner, the (un)check buttons in the bottom left:
-		alignButtons(
-			self.w,
-			rightButtons=(self.w.runButton, ),
-			leftButtons=(self.w.uncheckAllButton, self.w.checkAllButton),
-			inset=inset,
-			leftGap=6,
-		)
+		alignButtonsRight(self.w, (self.w.uncheckAllButton, self.w.checkAllButton, self.w.runButton), inset=inset)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -484,14 +484,23 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 		linePos += lineHeight
 
 		# Run Button:
-		self.w.runButton = vanilla.Button((-80 - inset, -20 - inset, -inset, -inset), "Build", callback=self.BuildCirclesSquaresTrianglesMain)
+		self.w.runButton = vanilla.Button("auto", "Build", callback=self.BuildCirclesSquaresTrianglesMain)
 		self.w.setDefaultButton(self.w.runButton)
 
 		# (un)check all checkboxes:
-		self.w.checkAllButton = vanilla.Button((-180 - inset, -20 - inset, -90 - inset, -inset), "Check All", callback=self.checkOrUncheckAll)
+		self.w.checkAllButton = vanilla.Button("auto", "Check All", callback=self.checkOrUncheckAll)
 		self.w.checkAllButton.setToolTip("Activates all checkboxes above the separator line.")
-		self.w.uncheckAllButton = vanilla.Button((-300 - inset, -20 - inset, -190 - inset, -inset), "Uncheck All", callback=self.checkOrUncheckAll)
+		self.w.uncheckAllButton = vanilla.Button("auto", "Uncheck All", callback=self.checkOrUncheckAll)
 		self.w.uncheckAllButton.setToolTip("Deactivates all checkboxes above the separator line.")
+		self.w.addAutoPosSizeRules(
+			[
+				"H:[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"V:[uncheckAllButton]-inset-|",
+				"V:[checkAllButton]-inset-|",
+				"V:[runButton]-inset-|",
+			],
+			metrics={"inset": inset, "gap": 10},
+		)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Build Glyphs/Build Small Figures.py
+++ b/Build Glyphs/Build Small Figures.py
@@ -67,9 +67,17 @@ class smallFigureBuilder(mekkaObject):
 		linePos += lineHeight
 
 		# Run Button:
-		self.w.reportButton = vanilla.Button((-200 - 15, -20 - 15, -95, -15), "Open Report", callback=self.openMacroWindow)
-		self.w.runButton = vanilla.Button((-70 - 15, -20 - 15, -15, -15), "Build", callback=self.smallFigureBuilderMain)
+		self.w.reportButton = vanilla.Button("auto", "Open Report", callback=self.openMacroWindow)
+		self.w.runButton = vanilla.Button("auto", "Build", callback=self.smallFigureBuilderMain)
 		self.w.setDefaultButton(self.w.runButton)
+		self.w.addAutoPosSizeRules(
+			[
+				"H:[reportButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"V:[reportButton]-inset-|",
+				"V:[runButton]-inset-|",
+			],
+			metrics={"inset": inset, "gap": 10},
+		)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Build Glyphs/Build Small Figures.py
+++ b/Build Glyphs/Build Small Figures.py
@@ -6,6 +6,7 @@ Takes a default set of figures (e.g., dnom), and derives the others (.numr, supe
 """
 
 import vanilla
+from AppKit import NSLayoutConstraintOrientationHorizontal, NSLayoutPriorityDefaultHigh, NSLayoutPriorityDefaultLow, NSLayoutPriorityRequired, NSLayoutConstraintOrientationVertical, NSLayoutPriorityWindowSizeStayPut
 from Foundation import NSPoint
 from GlyphsApp import Glyphs, GSComponent
 from mekkablue import mekkaObject, newGlyphWithName
@@ -25,58 +26,78 @@ class smallFigureBuilder(mekkaObject):
 	def __init__(self):
 		# Window 'self.w':
 		windowWidth = 400
-		windowHeight = 212
-		windowWidthResize = 400  # user can resize width by this value
-		windowHeightResize = 0  # user can resize height by this value
+		windowHeight = 230  # Auto Layout grows the window if the content needs more
+		# no minSize/maxSize: that keeps the window unresizable, and keeps the size limits
+		# out of Auto Layout's way
 		self.w = vanilla.FloatingWindow(
 			(windowWidth, windowHeight),  # default window size
 			"Build Small Figures",  # window title
-			minSize=(windowWidth, windowHeight + 19),  # minimum size (for resizing)
-			maxSize=(windowWidth + windowWidthResize, windowHeight + windowHeightResize + 19),  # maximum size (for resizing)
 			autosaveName=self.domain("mainwindow")  # stores last window position and size
 		)
 
 		# UI elements:
-		inset, linePos, lineHeight = 15, 10, 23
+		# the only multi-line label in this window; its height is fixed, so the layout
+		# never has to derive a height from wrapped text:
+		self.w.text_0 = vanilla.TextBox("auto", "Takes the Default Suffix figures (e.g. .dnom) and builds compound copies with suffixes in Derivatives (comma-separated suffix:yOffset pairs). Respects Italic Angle when placing components.", sizeStyle='small', selectable=True)
 
-		self.w.text_0 = vanilla.TextBox((inset, linePos + 2, -inset, 60), "Takes the Default Suffix figures (e.g. .dnom) and builds compound copies with suffixes in Derivatives (comma-separated suffix:yOffset pairs). Respects Italic Angle when placing components.", sizeStyle='small', selectable=True)
-		linePos += round(lineHeight * 2.2)
-
-		self.w.text_1 = vanilla.TextBox((inset - 1, linePos + 3, 100, 14), "Default Suffix:", sizeStyle='small')
-		self.w.default = vanilla.EditText((100, linePos, -inset, 20), "", sizeStyle='small', callback=self.SavePreferences)
+		self.w.text_1 = vanilla.TextBox("auto", "Default Suffix:", sizeStyle='small')
+		self.w.default = vanilla.EditText("auto", "", sizeStyle='small', callback=self.SavePreferences)
 		self.w.default.setToolTip(u"Small figures with this suffix will be used as components in the derivative figures.")
-		linePos += lineHeight
 
-		self.w.text_2 = vanilla.TextBox((inset - 1, linePos + 3, 75, 14), "Derivatives:", sizeStyle='small')
-		self.w.derive = vanilla.EditText((100, linePos, -inset, 20), "", sizeStyle='small', callback=self.SavePreferences)
+		self.w.text_2 = vanilla.TextBox("auto", "Derivatives:", sizeStyle='small')
+		self.w.derive = vanilla.EditText("auto", "", sizeStyle='small', callback=self.SavePreferences)
 		self.w.derive.setToolTip(u"Add suffix:offset pairs (with a colon in between), separated by commas, e.g., ‘.numr:250, superior:350, inferior:-125’. Include the dot if the suffix is a dot suffix. The script will create the figure glyphs or overwrite existing ones.")
-		linePos += lineHeight
 
-		self.w.currentMasterOnly = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "Only apply to current master (uncheck for all masters)", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.currentMasterOnly = vanilla.CheckBox("auto", "Only apply to current master (uncheck for all masters)", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.currentMasterOnly.setToolTip(u"If checked, will only process the currently selected master in the frontmost font. Useful if you want to use different values for different masters.")
-		linePos += lineHeight
 
-		self.w.decomposeDefaultFigures = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), u"Decompose small figures with Default Suffix", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.decomposeDefaultFigures = vanilla.CheckBox("auto", u"Decompose small figures with Default Suffix", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.decomposeDefaultFigures.setToolTip(u"If checked, will decompose the small figures with the suffix entered in ‘Default Suffix’, before placing them as components in the derivatives. Useful if the current defaults are e.g. numr, and you want to reset it to dnom, and keep all others (numr, superior, inferior) as compounds.")
-		linePos += lineHeight
 
-		self.w.openTab = vanilla.CheckBox((inset + 2, linePos - 1, 190, 20), u"Open tab with affected glyphs", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.openTab = vanilla.CheckBox("auto", u"Open tab with affected glyphs", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.openTab.setToolTip(u"If checked, will open a new tab with all figures that have default and derivative suffixes. Useful for checking.")
-		self.w.reuseTab = vanilla.CheckBox((inset + 190, linePos - 1, -inset, 20), u"Reuse current tab", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.reuseTab = vanilla.CheckBox("auto", u"Reuse current tab", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.reuseTab.setToolTip(u"If checked, will reuse the current tab rather than open a new one. Will open a new one if no tab is currently open and active, though.")
-		linePos += lineHeight
 
 		# Run Button:
 		self.w.reportButton = vanilla.Button("auto", "Open Report", callback=self.openMacroWindow)
 		self.w.runButton = vanilla.Button("auto", "Build", callback=self.smallFigureBuilderMain)
 		self.w.setDefaultButton(self.w.runButton)
+
+		# the description is the one block that wraps: it takes the width it is given
+		# (and the height fixed in the rules below) instead of demanding one long line
+		self.w.text_0.getNSTextField().setContentCompressionResistancePriority_forOrientation_(NSLayoutPriorityDefaultLow, NSLayoutConstraintOrientationHorizontal)
+
+		# the two field labels hug their text and share a width, so the fields line up:
+		for label in (self.w.text_1, self.w.text_2):
+			nsLabel = label.getNSTextField()
+			nsLabel.setContentHuggingPriority_forOrientation_(NSLayoutPriorityDefaultHigh, NSLayoutConstraintOrientationHorizontal)
+			nsLabel.setContentCompressionResistancePriority_forOrientation_(NSLayoutPriorityRequired, NSLayoutConstraintOrientationHorizontal)
+
+		# checkboxes and square buttons do not resist vertical stretching by default; with
+		# every control hugging vertically and no flexible gap in the chain, the window ends
+		# up exactly as tall as Auto Layout needs. NSLayoutPriorityWindowSizeStayPut (500) is
+		# the level at which a constraint starts outranking "keep the window size".
+		for view in self.w.getNSWindow().contentView().subviews():
+			view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+
 		self.w.addAutoPosSizeRules(
 			[
-				"H:[reportButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"H:|-inset-[text_0]-inset-|",
+				"H:|-inset-[text_1]-gap-[default]-inset-|",
+				"H:|-inset-[text_2]-gap-[derive]-inset-|",
+				"H:|-inset-[currentMasterOnly]-(>=inset)-|",
+				"H:|-inset-[decomposeDefaultFigures]-(>=inset)-|",
+				"H:|-inset-[openTab]-gap-[reuseTab]-(>=inset)-|",
+				"H:|-(>=inset)-[reportButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"V:|-gap-[text_0]-row-[default]-row-[derive]-row-[currentMasterOnly]-row-[decomposeDefaultFigures]-row-[openTab]-inset-[runButton]-inset-|",
 				"V:[reportButton]-inset-|",
-				"V:[runButton]-inset-|",
+				{"view1": self.w.text_2, "attribute1": "width", "view2": self.w.text_1, "attribute2": "width"},
+				{"view1": self.w.text_1, "attribute1": "centerY", "view2": self.w.default, "attribute2": "centerY"},
+				{"view1": self.w.text_2, "attribute1": "centerY", "view2": self.w.derive, "attribute2": "centerY"},
+				{"view1": self.w.reuseTab, "attribute1": "centerY", "view2": self.w.openTab, "attribute2": "centerY"},
 			],
-			metrics={"inset": inset, "gap": 10},
+			metrics={"inset": 15, "gap": 8, "row": 8},
 		)
 
 		# Load Settings:

--- a/Build Glyphs/Build Small Figures.py
+++ b/Build Glyphs/Build Small Figures.py
@@ -8,7 +8,7 @@ Takes a default set of figures (e.g., dnom), and derives the others (.numr, supe
 import vanilla
 from Foundation import NSPoint
 from GlyphsApp import Glyphs, GSComponent
-from mekkablue import alignButtonsRight, mekkaObject, newGlyphWithName
+from mekkablue import mekkaObject, newGlyphWithName
 from mekkablue.geometry import italicize
 
 
@@ -70,9 +70,6 @@ class smallFigureBuilder(mekkaObject):
 		self.w.reportButton = vanilla.Button((-200 - 15, -20 - 15, -95, -15), "Open Report", callback=self.openMacroWindow)
 		self.w.runButton = vanilla.Button((-70 - 15, -20 - 15, -15, -15), "Build", callback=self.smallFigureBuilderMain)
 		self.w.setDefaultButton(self.w.runButton)
-
-		# fit the button row to the button metrics of the running macOS version:
-		alignButtonsRight(self.w, (self.w.reportButton, self.w.runButton))
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Build Glyphs/Build Symbols.py
+++ b/Build Glyphs/Build Symbols.py
@@ -13,6 +13,7 @@ import vanilla
 import math
 from GlyphsApp import Glyphs, GSGlyph, GSPath, GSNode, GSAnchor, GSOFFCURVE, GSCURVE, GSSMOOTH, distance
 from mekkablue import mekkaObject
+from AppKit import NSLayoutConstraintOrientationVertical, NSLayoutPriorityWindowSizeStayPut
 from mekkablue.geometry import transform, italicize, offsetLayer
 
 
@@ -656,8 +657,8 @@ class BuildSymbols(mekkaObject):
 
 	def __init__(self):
 		# Window 'self.w':
-		windowWidth = 426
-		windowHeight = 208
+		windowWidth = 434
+		windowHeight = 1  # Auto Layout grows the window to the required size
 		self.w = vanilla.FloatingWindow(
 			(windowWidth, windowHeight),  # default window size
 			"Build Symbols",  # window title
@@ -665,78 +666,101 @@ class BuildSymbols(mekkaObject):
 		)
 
 		# UI elements:
-		linePos, inset, lineHeight, column = 12, 15, 22, 100
 
-		self.w.descriptionText = vanilla.TextBox((inset, linePos + 2, -inset, 14), "Create the following symbols automatically. See tooltips for requirements.", sizeStyle='small', selectable=True)
-		linePos += lineHeight
+		self.w.descriptionText = vanilla.TextBox("auto", "Create the following symbols automatically. See tooltips for requirements.", sizeStyle='small', selectable=True)
 
-		self.w.buildEstimated = vanilla.CheckBox((inset + 2, linePos, -inset, 20), "estimated", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildEstimated = vanilla.CheckBox("auto", "estimated", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildEstimated.setToolTip("Will build estimated ℮ and scale it to the size of your lining zero, if available.")
 
-		self.w.buildBars = vanilla.CheckBox((inset + column, linePos, -inset, 20), "bar, brokenbar", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildBars = vanilla.CheckBox("auto", "bar, brokenbar", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildBars.setToolTip("Will model bar | and brokenbar ¦ after your slash /, or if there is no slash, use the master’s stem values for their size.")
 
-		self.w.buildEmptyset = vanilla.CheckBox((inset + int(column * 2.1), linePos, -inset, 20), "emptyset", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildEmptyset = vanilla.CheckBox("auto", "emptyset", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildEmptyset.setToolTip("Will build emptyset. Not yet implemented, sorry.")
 		self.w.buildEmptyset.enable(False)
 
-		self.w.buildDottedcircle = vanilla.CheckBox((inset + column * 3, linePos, -inset, 20), "dottedCircle", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildDottedcircle = vanilla.CheckBox("auto", "dottedCircle", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildDottedcircle.setToolTip("Will build dottedCircle ◌.")
-		linePos += lineHeight
 
-		self.w.buildCurrency = vanilla.CheckBox((inset + 2, linePos, -inset, 20), "currency", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildCurrency = vanilla.CheckBox("auto", "currency", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildCurrency.setToolTip("Will build currency.")
 
-		self.w.buildLozenge = vanilla.CheckBox((inset + column, linePos, -inset, 20), "lozenge", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildLozenge = vanilla.CheckBox("auto", "lozenge", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildLozenge.setToolTip("Will build lozenge.")
 
-		self.w.buildProduct = vanilla.CheckBox((inset + int(column * 2.1), linePos, -inset, 20), "product", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildProduct = vanilla.CheckBox("auto", "product", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildProduct.setToolTip("Will build product. Not yet implemented, sorry.")
 		self.w.buildProduct.enable(False)
-		linePos += lineHeight
 
-		self.w.buildSummation = vanilla.CheckBox((inset + 2, linePos, -inset, 20), "summation", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildSummation = vanilla.CheckBox("auto", "summation", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildSummation.setToolTip("Will build summation. Not yet implemented, sorry.")
 		self.w.buildSummation.enable(False)
 
-		self.w.buildRadical = vanilla.CheckBox((inset + column, linePos, -inset, 20), "radical", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildRadical = vanilla.CheckBox("auto", "radical", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildRadical.setToolTip("Will build radical. Not yet implemented, sorry.")
 		self.w.buildRadical.enable(False)
 
-		self.w.buildNotdef = vanilla.CheckBox((inset + int(column * 2.1), linePos, -inset, 20), ".notdef", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.buildNotdef = vanilla.CheckBox("auto", ".notdef", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.buildNotdef.setToolTip("Will build the mandatory .notdef glyph based on the boldest available question mark.")
-		linePos += lineHeight
 
 		# ----------- SEPARATOR LINE -----------
-		self.w.line = vanilla.HorizontalLine((inset, int(linePos + 0.5 * lineHeight - 1), -inset, 1))
-		linePos += lineHeight
+		self.w.line = vanilla.HorizontalLine("auto")
 
 		# Other options:
-		self.w.override = vanilla.CheckBox((inset + 2, linePos, -inset, 20), "Overwrite existing glyphs", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.override = vanilla.CheckBox("auto", "Overwrite existing glyphs", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.override.setToolTip("If checked, will create fresh symbols even if they already exist. If unchecked, will skip glyphs that already exist.")
-		self.w.backupLayers = vanilla.CheckBox((inset + 180, linePos, -inset, 20), "Backup existing layers", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.backupLayers = vanilla.CheckBox("auto", "Backup existing layers", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.backupLayers.setToolTip("If checked, will create backup layers when the glyph gets overwritten. Only available in combination with Override option.")
-		linePos += lineHeight
 
-		self.w.newTab = vanilla.CheckBox((inset + 2, linePos - 1, 180, 20), "Open tab with new glyphs", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.newTab = vanilla.CheckBox("auto", "Open tab with new glyphs", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.newTab.setToolTip("If checked, will open a new tab with the newly created symbols.")
-		self.w.reuseTab = vanilla.CheckBox((inset + 180, linePos - 1, -inset, 20), "Reuse current tab", value=True, callback=self.SavePreferences, sizeStyle='small')
+		self.w.reuseTab = vanilla.CheckBox("auto", "Reuse current tab", value=True, callback=self.SavePreferences, sizeStyle='small')
 		self.w.reuseTab.setToolTip("If checked, will reuse the current tab, and open a new tab only if there is no Edit tab open already. Highly recommended.")
-		linePos += lineHeight
 
 		# Run Button:
 		self.w.uncheckAllButton = vanilla.Button("auto", "Uncheck All", callback=self.checkAll)
 		self.w.checkAllButton = vanilla.Button("auto", "Check All", callback=self.checkAll)
 		self.w.runButton = vanilla.Button("auto", "Build", callback=self.BuildSymbolsMain)
 		self.w.setDefaultButton(self.w.runButton)
+
+		# one shared width per grid column, so the checkboxes line up across the rows:
+		gridCheckBoxes = (
+			self.w.buildEstimated, self.w.buildBars, self.w.buildEmptyset, self.w.buildDottedcircle,
+			self.w.buildCurrency, self.w.buildLozenge, self.w.buildProduct,
+			self.w.buildSummation, self.w.buildRadical, self.w.buildNotdef,
+		)
+		columnRules = [
+			{"view1": cell, "attribute1": "width", "view2": gridCheckBoxes[0], "attribute2": "width"}
+			for cell in gridCheckBoxes[1:]
+		] + [
+			{"view1": self.w.newTab, "attribute1": "width", "view2": self.w.override, "attribute2": "width"},
+		]
+		# checkboxes and square buttons do not resist vertical stretching by default.
+		# With every control hugging vertically and no flexible gap in the chain below,
+		# the window takes exactly the height Auto Layout needs -- NSLayoutPriorityWindowSizeStayPut
+		# is the level above which a constraint outranks "keep the window size".
+		for view in self.w.getNSWindow().contentView().subviews():
+			view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+
 		self.w.addAutoPosSizeRules(
 			[
-				"H:[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"H:|-inset-[descriptionText]-inset-|",
+				"H:|-inset-[buildEstimated]-gap-[buildBars]-gap-[buildEmptyset]-gap-[buildDottedcircle]-(>=inset)-|",
+				"H:|-inset-[buildCurrency]-gap-[buildLozenge]-gap-[buildProduct]",
+				"H:|-inset-[buildSummation]-gap-[buildRadical]-gap-[buildNotdef]",
+				"H:|-inset-[line]-inset-|",
+				"H:|-inset-[override]-gap-[backupLayers]-inset-|",
+				"H:|-inset-[newTab]-gap-[reuseTab]-inset-|",
+				"H:|-(>=inset)-[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				# one vertical chain per column; equal row heights keep the rows aligned
+				"V:|-row-[descriptionText]-row-[buildEstimated]-row-[buildCurrency]-row-[buildSummation]-row-[line(1)]-row-[override]-row-[newTab]-inset-[runButton]-inset-|",
+				"V:|-row-[descriptionText]-row-[buildBars]-row-[buildLozenge]-row-[buildRadical]-row-[line]-row-[backupLayers]-row-[reuseTab]",
+				"V:|-row-[descriptionText]-row-[buildEmptyset]-row-[buildProduct]-row-[buildNotdef]",
+				"V:|-row-[descriptionText]-row-[buildDottedcircle]",
 				"V:[uncheckAllButton]-inset-|",
 				"V:[checkAllButton]-inset-|",
-				"V:[runButton]-inset-|",
-			],
-			metrics={"inset": inset, "gap": 10},
+			] + columnRules,
+			metrics={"inset": 15, "gap": 8, "row": 8},
 		)
 
 		# Load Settings:

--- a/Build Glyphs/Build Symbols.py
+++ b/Build Glyphs/Build Symbols.py
@@ -212,7 +212,7 @@ def drawPenDataInLayer(thisLayer, penData, closePath=True):
 			elif len(thisSegment) == 3:  # curveto (3 x/y tuples)
 				pen.curveTo(thisSegment[0], thisSegment[1], thisSegment[2])
 			else:
-				print("Path drawing error. Could not process this segment:\n" % thisSegment)
+				print("Path drawing error. Could not process this segment: %s\n" % thisSegment)
 		if closePath:
 			pen.closePath()
 		pen.endPath()

--- a/Build Glyphs/Build Symbols.py
+++ b/Build Glyphs/Build Symbols.py
@@ -725,10 +725,19 @@ class BuildSymbols(mekkaObject):
 		linePos += lineHeight
 
 		# Run Button:
-		self.w.uncheckAllButton = vanilla.Button((-315 - inset, -20 - inset, -200 - inset, -inset), "Uncheck All", callback=self.checkAll)
-		self.w.checkAllButton = vanilla.Button((-190 - inset, -20 - inset, -90 - inset, -inset), "Check All", callback=self.checkAll)
-		self.w.runButton = vanilla.Button((-80 - inset, -20 - inset, -inset, -inset), "Build", callback=self.BuildSymbolsMain)
+		self.w.uncheckAllButton = vanilla.Button("auto", "Uncheck All", callback=self.checkAll)
+		self.w.checkAllButton = vanilla.Button("auto", "Check All", callback=self.checkAll)
+		self.w.runButton = vanilla.Button("auto", "Build", callback=self.BuildSymbolsMain)
 		self.w.setDefaultButton(self.w.runButton)
+		self.w.addAutoPosSizeRules(
+			[
+				"H:[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"V:[uncheckAllButton]-inset-|",
+				"V:[checkAllButton]-inset-|",
+				"V:[runButton]-inset-|",
+			],
+			metrics={"inset": inset, "gap": 10},
+		)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Build Glyphs/Build Symbols.py
+++ b/Build Glyphs/Build Symbols.py
@@ -12,7 +12,7 @@ from Foundation import NSPoint, NSRect, NSSize, NSAffineTransform
 import vanilla
 import math
 from GlyphsApp import Glyphs, GSGlyph, GSPath, GSNode, GSAnchor, GSOFFCURVE, GSCURVE, GSSMOOTH, distance
-from mekkablue import alignButtonsRight, mekkaObject
+from mekkablue import mekkaObject
 from mekkablue.geometry import transform, italicize, offsetLayer
 
 
@@ -729,9 +729,6 @@ class BuildSymbols(mekkaObject):
 		self.w.checkAllButton = vanilla.Button((-190 - inset, -20 - inset, -90 - inset, -inset), "Check All", callback=self.checkAll)
 		self.w.runButton = vanilla.Button((-80 - inset, -20 - inset, -inset, -inset), "Build", callback=self.BuildSymbolsMain)
 		self.w.setDefaultButton(self.w.runButton)
-
-		# fit the button row to the button metrics of the running macOS version:
-		alignButtonsRight(self.w, (self.w.uncheckAllButton, self.w.checkAllButton, self.w.runButton), inset=inset)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -8,7 +8,7 @@ Build and sync quotes: create single and double quotes with cursive attachment a
 import vanilla
 from Foundation import NSPoint
 from GlyphsApp import Glyphs, GSAnchor, GSComponent, GSPath, GSNode, LINE, GSMetricsTypeCapHeight
-from mekkablue import alignButtons, mekkaObject, newGlyphWithName
+from mekkablue import mekkaObject, newGlyphWithName
 
 # Maps single quote → double quote
 SINGLE_TO_DOUBLE = {
@@ -237,15 +237,6 @@ class QuoteManager(mekkaObject):
 			"Build all selected quote glyphs: fills empty layers with mirrored paths, builds double quotes as composites, sets metrics keys, anchors, and kern groups."
 		)
 		self.w.setDefaultButton(self.w.buildButton)
-
-		# fit the button row to the button metrics of the running macOS version:
-		alignButtons(
-			self.w,
-			rightButtons=(self.w.updateButton, self.w.buildButton),
-			leftButtons=(self.w.editSinglesButton, ),
-			inset=inset,
-			assumedHeight=22,
-		)
 
 		self.LoadPreferences()
 		self.w.open()

--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -218,25 +218,28 @@ class QuoteManager(mekkaObject):
 		self.w.reuseTab.setToolTip("Replace the current tab's content instead of opening a new tab.")
 		linePos += lineHeight
 
-		self.w.editSinglesButton = vanilla.Button(
-			(inset, -22 - inset, 100, -inset), "Edit Singles", callback=self.editSingles
-		)
+		self.w.editSinglesButton = vanilla.Button("auto", "Edit Singles", callback=self.editSingles)
 		self.w.editSinglesButton.setToolTip(
 			"Open the default glyph(s) in a tab for editing. Creates them if they don't exist yet, and adds #entry/#exit anchors if missing."
 		)
-		self.w.updateButton = vanilla.Button(
-			(-inset - 145, -22 - inset, 75, -inset), "Update", callback=self.update
-		)
+		self.w.updateButton = vanilla.Button("auto", "Update", callback=self.update)
 		self.w.updateButton.setToolTip(
 			"Update metrics keys, anchors, and kern groups for all selected quote groups. Does not overwrite existing paths."
 		)
-		self.w.buildButton = vanilla.Button(
-			(-inset - 65, -22 - inset, 65, -inset), "Build", callback=self.build
-		)
+		self.w.buildButton = vanilla.Button("auto", "Build", callback=self.build)
 		self.w.buildButton.setToolTip(
 			"Build all selected quote glyphs: fills empty layers with mirrored paths, builds double quotes as composites, sets metrics keys, anchors, and kern groups."
 		)
 		self.w.setDefaultButton(self.w.buildButton)
+		self.w.addAutoPosSizeRules(
+			[
+				"H:|-inset-[editSinglesButton(>=70)]-(>=gap)-[updateButton(>=70)]-gap-[buildButton(>=70)]-inset-|",
+				"V:[editSinglesButton]-inset-|",
+				"V:[updateButton]-inset-|",
+				"V:[buildButton]-inset-|",
+			],
+			metrics={"inset": inset, "gap": 10},
+		)
 
 		self.LoadPreferences()
 		self.w.open()

--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -9,6 +9,7 @@ import vanilla
 from Foundation import NSPoint
 from GlyphsApp import Glyphs, GSAnchor, GSComponent, GSPath, GSNode, LINE, GSMetricsTypeCapHeight
 from mekkablue import mekkaObject, newGlyphWithName
+from AppKit import NSLayoutConstraintOrientationHorizontal, NSLayoutPriorityDefaultHigh, NSLayoutPriorityRequired, NSLayoutConstraintOrientationVertical, NSLayoutPriorityWindowSizeStayPut
 
 # Maps single quote → double quote
 SINGLE_TO_DOUBLE = {
@@ -70,153 +71,72 @@ class QuoteManager(mekkaObject):
 	}
 
 	def __init__(self):
-		windowWidth = 360
-		windowHeight = 320
-		windowWidthResize = 100
-		windowHeightResize = 0
+		windowWidth = 320
+		windowHeight = 1  # Auto Layout grows the window if the content needs more
 		self.w = vanilla.FloatingWindow(
 			(windowWidth, windowHeight),
 			"Quote Manager",
-			minSize=(windowWidth - 30, windowHeight),
-			maxSize=(windowWidth + windowWidthResize, windowHeight + windowHeightResize),
 			autosaveName=self.domain("mainwindow"),
 		)
 
-		linePos, inset, lineHeight = 12, 15, 22
-		col2 = inset + 165  # second column x offset
-
-		self.w.titleText = vanilla.TextBox(
-			(inset, linePos + 2, -inset, 14),
-			"Create quotes with synced spacing and kern groups:",
-			sizeStyle="small",
-			selectable=True,
-		)
-		linePos += lineHeight
+		self.w.titleText = vanilla.TextBox("auto", "Create quotes with synced spacing and kern groups:", sizeStyle="small", selectable=True)
 
 		# Row 1: Left guillemets | Left quotes
-		self.w.doLeftGuillemets = vanilla.CheckBox(
-			(inset, linePos, 165, 20), "Left guillemets", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
-		self.w.doLeftGuillemets.setToolTip("Create or update guilsinglleft, guillemetleft (‹ «)")
-		self.w.doLeftQuotes = vanilla.CheckBox(
-			(col2, linePos, -inset, 20), "Left quotes", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
+		self.w.doLeftGuillemets = vanilla.CheckBox("auto", "Left guillemets", value=True, callback=self.SavePreferences, sizeStyle="small")
+		self.w.doLeftGuillemets.setToolTip("Create or update guilsinglleft, guillemetleft (\u2039 \xab)")
+		self.w.doLeftQuotes = vanilla.CheckBox("auto", "Left quotes", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.doLeftQuotes.setToolTip("Create or update quoteleft, quotedblleft (\u2018 \u201c)")
-		linePos += lineHeight
 
 		# Row 2: Right guillemets | Right quotes
-		self.w.doRightGuillemets = vanilla.CheckBox(
-			(inset, linePos, 165, 20), "Right guillemets", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
-		self.w.doRightGuillemets.setToolTip("Create or update guilsinglright, guillemetright (› »)")
-		self.w.doRightQuotes = vanilla.CheckBox(
-			(col2, linePos, -inset, 20), "Right quotes", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
+		self.w.doRightGuillemets = vanilla.CheckBox("auto", "Right guillemets", value=True, callback=self.SavePreferences, sizeStyle="small")
+		self.w.doRightGuillemets.setToolTip("Create or update guilsinglright, guillemetright (\u203a \xbb)")
+		self.w.doRightQuotes = vanilla.CheckBox("auto", "Right quotes", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.doRightQuotes.setToolTip("Create or update quoteright, quotedblright (\u2019 \u201d)")
-		linePos += lineHeight
 
 		# Row 3: Dumb quotes | Apostrophe
-		self.w.doDumbQuotes = vanilla.CheckBox(
-			(inset, linePos, 165, 20), "Dumb quotes", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
+		self.w.doDumbQuotes = vanilla.CheckBox("auto", "Dumb quotes", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.doDumbQuotes.setToolTip("Create or update quotesingle, quotedbl (' \")")
-		self.w.doApostrophes = vanilla.CheckBox(
-			(col2, linePos, -inset, 20), "Apostrophe", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
-		self.w.doApostrophes.setToolTip(
-			"Create or update apostrophemod, commareversedmod, commaturnedmod (ʼ ʽ ʻ)"
-		)
-		linePos += lineHeight
+		self.w.doApostrophes = vanilla.CheckBox("auto", "Apostrophe", value=True, callback=self.SavePreferences, sizeStyle="small")
+		self.w.doApostrophes.setToolTip("Create or update apostrophemod, commareversedmod, commaturnedmod (\u02bc \u02bd \u02bb)")
 
 		# Row 4: Base quotes | Reversed quotes
-		self.w.doBaseQuotes = vanilla.CheckBox(
-			(inset, linePos, 165, 20), "Base quotes", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
-		self.w.doBaseQuotes.setToolTip("Create or update quotesinglbase, quotedblbase (‚ „)")
-		self.w.doReversedQuotes = vanilla.CheckBox(
-			(col2, linePos, -inset, 20), "Reversed quotes", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
-		self.w.doReversedQuotes.setToolTip(
-			"Create or update quotereversed, quotedblrightreversed (‛ ‟)"
-		)
-		linePos += lineHeight
+		self.w.doBaseQuotes = vanilla.CheckBox("auto", "Base quotes", value=True, callback=self.SavePreferences, sizeStyle="small")
+		self.w.doBaseQuotes.setToolTip("Create or update quotesinglbase, quotedblbase (\u201a \u201e)")
+		self.w.doReversedQuotes = vanilla.CheckBox("auto", "Reversed quotes", value=True, callback=self.SavePreferences, sizeStyle="small")
+		self.w.doReversedQuotes.setToolTip("Create or update quotereversed, quotedblrightreversed (\u201b \u201f)")
 
-		self.w.divider1 = vanilla.HorizontalLine((inset, linePos + 6, -inset, 1))
-		linePos += lineHeight
+		self.w.divider1 = vanilla.HorizontalLine("auto")
 
-		self.w.useQuoteDefault = vanilla.CheckBox(
-			(inset, linePos, 140, 20), "Quotes based on", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
+		self.w.useQuoteDefault = vanilla.CheckBox("auto", "Quotes based on", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.useQuoteDefault.setToolTip(
 			"Use a specific single quote as the reference for metrics keys, anchor positions, and path building."
 		)
-		self.w.defaultQuote = vanilla.PopUpButton(
-			(inset + 130, linePos + 1, -inset, 18),
-			DEFAULT_QUOTE_CHOICES,
-			callback=self.SavePreferences,
-			sizeStyle="small",
-		)
+		self.w.defaultQuote = vanilla.PopUpButton("auto", DEFAULT_QUOTE_CHOICES, callback=self.SavePreferences, sizeStyle="small")
 		self.w.defaultQuote.setToolTip(
 			"The single quote all other quotes are derived from. Draw this glyph first, then click Build."
 		)
-		linePos += lineHeight
 
-		self.w.useGuillemetsDefault = vanilla.CheckBox(
-			(inset, linePos, 140, 20),
-			"Guillemets based on",
-			value=True,
-			callback=self.SavePreferences,
-			sizeStyle="small",
-		)
+		self.w.useGuillemetsDefault = vanilla.CheckBox("auto", "Guillemets based on", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.useGuillemetsDefault.setToolTip(
 			"Use a specific guillemet as the reference for guillemet metrics keys, anchor positions, and path building."
 		)
-		self.w.defaultGuillemet = vanilla.PopUpButton(
-			(inset + 130, linePos + 1, -inset, 18),
-			DEFAULT_GUILLEMET_CHOICES,
-			callback=self.SavePreferences,
-			sizeStyle="small",
-		)
+		self.w.defaultGuillemet = vanilla.PopUpButton("auto", DEFAULT_GUILLEMET_CHOICES, callback=self.SavePreferences, sizeStyle="small")
 		self.w.defaultGuillemet.setToolTip(
 			"The single guillemet all other guillemets are derived from. The other guillemet will be a mirrored composite."
 		)
-		linePos += lineHeight
 
-		self.w.preserveExisting = vanilla.CheckBox(
-			(inset, linePos, -inset, 20),
-			"Preserve existing quotes when building",
-			value=True,
-			callback=self.SavePreferences,
-			sizeStyle="small",
-		)
+		self.w.preserveExisting = vanilla.CheckBox("auto", "Preserve existing quotes when building", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.preserveExisting.setToolTip(
 			"When on, only empty layers are filled. When off, all quotes are rebuilt from scratch based on the default single quote/guillemet."
 		)
-		linePos += lineHeight
 
-		self.w.backupInBackground = vanilla.CheckBox(
-			(inset, linePos, -inset, 20),
-			"Backup in background",
-			value=False,
-			callback=self.SavePreferences,
-			sizeStyle="small",
-		)
+		self.w.backupInBackground = vanilla.CheckBox("auto", "Backup in background", value=False, callback=self.SavePreferences, sizeStyle="small")
 		self.w.backupInBackground.setToolTip("Decomposed copy of the current quotes")
-		linePos += lineHeight
 
-		self.w.openTab = vanilla.CheckBox(
-			(inset, linePos, 120, 20), "Open tab", value=True, callback=self.SavePreferences, sizeStyle="small"
-		)
+		self.w.openTab = vanilla.CheckBox("auto", "Open tab", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.openTab.setToolTip("Open a tab showing all affected glyphs after the operation.")
-		self.w.reuseTab = vanilla.CheckBox(
-			(inset + 120, linePos, -inset, 20),
-			"Reuse current tab",
-			value=True,
-			callback=self.SavePreferences,
-			sizeStyle="small",
-		)
+		self.w.reuseTab = vanilla.CheckBox("auto", "Reuse current tab", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.reuseTab.setToolTip("Replace the current tab's content instead of opening a new tab.")
-		linePos += lineHeight
 
 		self.w.editSinglesButton = vanilla.Button("auto", "Edit Singles", callback=self.editSingles)
 		self.w.editSinglesButton.setToolTip(
@@ -231,14 +151,55 @@ class QuoteManager(mekkaObject):
 			"Build all selected quote glyphs: fills empty layers with mirrored paths, builds double quotes as composites, sets metrics keys, anchors, and kern groups."
 		)
 		self.w.setDefaultButton(self.w.buildButton)
+
+		# the two checkbox labels in front of the popups hug their text and share a width:
+		for label in (self.w.useQuoteDefault, self.w.useGuillemetsDefault):
+			label.getNSButton().setContentHuggingPriority_forOrientation_(NSLayoutPriorityDefaultHigh, NSLayoutConstraintOrientationHorizontal)
+			label.getNSButton().setContentCompressionResistancePriority_forOrientation_(NSLayoutPriorityRequired, NSLayoutConstraintOrientationHorizontal)
+
+		# one shared width per grid column, so the two checkbox columns line up:
+		gridCheckBoxes = (
+			self.w.doLeftGuillemets, self.w.doRightGuillemets, self.w.doDumbQuotes, self.w.doBaseQuotes, self.w.openTab,
+			self.w.doLeftQuotes, self.w.doRightQuotes, self.w.doApostrophes, self.w.doReversedQuotes,
+		)
+		columnRules = [
+			{"view1": cell, "attribute1": "width", "view2": gridCheckBoxes[0], "attribute2": "width"}
+			for cell in gridCheckBoxes[1:]
+		] + [
+			{"view1": self.w.useGuillemetsDefault, "attribute1": "width", "view2": self.w.useQuoteDefault, "attribute2": "width"},
+		]
+
+		# checkboxes and square buttons do not resist vertical stretching by default; with
+		# every control hugging vertically and no flexible gap in the chain, the window ends
+		# up exactly as tall as Auto Layout needs. NSLayoutPriorityWindowSizeStayPut (500) is
+		# the level at which a constraint starts outranking "keep the window size".
+		for view in self.w.getNSWindow().contentView().subviews():
+			view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+
 		self.w.addAutoPosSizeRules(
 			[
+				"H:|-inset-[titleText]-inset-|",
+				"H:|-inset-[doLeftGuillemets]-gap-[doLeftQuotes]-(>=inset)-|",
+				"H:|-inset-[doRightGuillemets]-gap-[doRightQuotes]-(>=inset)-|",
+				"H:|-inset-[doDumbQuotes]-gap-[doApostrophes]-(>=inset)-|",
+				"H:|-inset-[doBaseQuotes]-gap-[doReversedQuotes]-(>=inset)-|",
+				"H:|-inset-[divider1]-inset-|",
+				"H:|-inset-[useQuoteDefault]-gap-[defaultQuote]-inset-|",
+				"H:|-inset-[useGuillemetsDefault]-gap-[defaultGuillemet]-inset-|",
+				"H:|-inset-[preserveExisting]-(>=inset)-|",
+				"H:|-inset-[backupInBackground]-(>=inset)-|",
+				"H:|-inset-[openTab]-gap-[reuseTab]-(>=inset)-|",
 				"H:|-inset-[editSinglesButton(>=70)]-(>=gap)-[updateButton(>=70)]-gap-[buildButton(>=70)]-inset-|",
+				# one vertical chain per column; equal row heights keep the rows aligned
+				"V:|-gap-[titleText]-row-[doLeftGuillemets]-row-[doRightGuillemets]-row-[doDumbQuotes]-row-[doBaseQuotes]-gap-[divider1(1)]-gap-[defaultQuote]-row-[defaultGuillemet]-row-[preserveExisting]-row-[backupInBackground]-row-[openTab]-inset-[buildButton]-inset-|",
+				"V:[titleText]-row-[doLeftQuotes]-row-[doRightQuotes]-row-[doApostrophes]-row-[doReversedQuotes]",
 				"V:[editSinglesButton]-inset-|",
 				"V:[updateButton]-inset-|",
-				"V:[buildButton]-inset-|",
-			],
-			metrics={"inset": inset, "gap": 10},
+				{"view1": self.w.useQuoteDefault, "attribute1": "centerY", "view2": self.w.defaultQuote, "attribute2": "centerY"},
+				{"view1": self.w.useGuillemetsDefault, "attribute1": "centerY", "view2": self.w.defaultGuillemet, "attribute2": "centerY"},
+				{"view1": self.w.reuseTab, "attribute1": "centerY", "view2": self.w.openTab, "attribute2": "centerY"},
+			] + columnRules,
+			metrics={"inset": 15, "gap": 8, "row": 8},
 		)
 
 		self.LoadPreferences()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,40 @@ linePos += lineHeight
 
 Negative coordinates are measured from the right/bottom edge (`-inset` = inset from right).
 
+### Bottom button rows — use Auto Layout
+
+Do **not** give the bottom buttons hardcoded `posSize` frames. Vanilla's frame-based layout
+inflates a button's `posSize` by `Button.frameAdjustments = (-6, -8, 12, 12)`, a compensation
+hardcoded for the classic Aqua bezel. On macOS 26 and later, buttons no longer draw that way,
+so hardcoded rows overlap each other and sit too close to the window edge.
+
+Give the buttons `"auto"` instead and place them with Visual Format Language rules. Auto Layout
+takes each button's intrinsic content size, so the row fits whatever the running macOS draws:
+
+```python
+self.w.uncheckAllButton = vanilla.Button("auto", "Uncheck All", callback=self.checkAll)
+self.w.checkAllButton = vanilla.Button("auto", "Check All", callback=self.checkAll)
+self.w.runButton = vanilla.Button("auto", "Build", callback=self.BuildSymbolsMain)
+self.w.setDefaultButton(self.w.runButton)
+self.w.addAutoPosSizeRules(
+	[
+		"H:[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+		"V:[uncheckAllButton]-inset-|",
+		"V:[checkAllButton]-inset-|",
+		"V:[runButton]-inset-|",
+	],
+	metrics={"inset": inset, "gap": 10},
+)
+```
+
+- The view names in the rules are the `self.w.<name>` attribute names.
+- Omitting the leading `|` anchors the chain to the right edge only, so the row stays
+  right-aligned and every button keeps its natural width.
+- For a split row, anchor both edges and let the middle gap flex:
+  `"H:|-inset-[editSinglesButton(>=70)]-(>=gap)-[updateButton(>=70)]-gap-[buildButton(>=70)]-inset-|"`
+- `(>=70)` keeps short titles from shrinking below the usual push-button width.
+- One `V:` rule per button pins it to the bottom edge; its height comes from the system.
+
 ## Shared Utility Functions (`__init__.py`)
 
 | Function | Description |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ from __future__ import division, print_function, unicode_literals
 __doc__ = """Description."""
 
 import vanilla
+from AppKit import NSLayoutConstraintOrientationVertical, NSLayoutPriorityWindowSizeStayPut
 from mekkablue import mekkaObject
 
 
@@ -119,26 +120,37 @@ class MyScript(mekkaObject):
 
 	def __init__(self):
 		windowWidth = 330
-		windowHeight = 240
-		windowWidthResize = 0   # extra width the user can resize by
-		windowHeightResize = 0  # extra height the user can resize by
+		windowHeight = 1  # Auto Layout grows the window to the height the content needs
+		# no minSize/maxSize: that keeps the window unresizable and the size limits out of
+		# Auto Layout's way (see “Window layout” below)
 		self.w = vanilla.FloatingWindow(
 			(windowWidth, windowHeight),
 			"My Script",
-			minSize=(windowWidth, windowHeight),
-			maxSize=(windowWidth + windowWidthResize, windowHeight + windowHeightResize),
-			autosaveName=self.domain("mainwindow"),  # persists window position/size
+			autosaveName=self.domain("mainwindow"),  # persists window position
 		)
 
 		# UI elements:
-		linePos, inset, lineHeight = 12, 15, 22
+		inset = 15
 
-		self.w.myCheckbox = vanilla.CheckBox((inset, linePos, -inset, 20), "Do the thing", value=True, callback=self.SavePreferences, sizeStyle="small")
+		self.w.myCheckbox = vanilla.CheckBox("auto", "Do the thing", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.myCheckbox.setToolTip("Tooltip explaining what this does.")
-		linePos += lineHeight
 
-		self.w.runButton = vanilla.Button((-80 - inset, -20 - inset, -inset, -inset), "Run", callback=self.run, sizeStyle="small")
+		self.w.runButton = vanilla.Button("auto", "Run", callback=self.run)
 		self.w.setDefaultButton(self.w.runButton)
+
+		# checkboxes and square buttons stretch vertically by default; with everything
+		# hugging, the window ends up exactly as tall as the content
+		for view in self.w.getNSWindow().contentView().subviews():
+			view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+
+		self.w.addAutoPosSizeRules(
+			[
+				"H:|-inset-[myCheckbox]-(>=inset)-|",
+				"H:|-(>=inset)-[runButton(>=70)]-inset-|",
+				"V:|-gap-[myCheckbox]-inset-[runButton]-inset-|",
+			],
+			metrics={"inset": inset, "gap": 8},
+		)
 
 		self.LoadPreferences()
 		self.w.open()
@@ -177,7 +189,7 @@ MyScript()
 | `self.uiElement(name)` | Returns UI element for a given pref name (supports dot notation for nested elements) |
 | `self.LoadPreferences()` | Populates all UI elements from prefs; calls `updateUI()` if defined |
 | `self.SavePreferences(sender)` | Saves all UI element values to prefs; calls `updateUI()` if defined |
-| `self.resizeWindowToMinimum()` | Resizes window to its minSize if the saved size is smaller (called automatically by `LoadPreferences()`) |
+| `self.resizeWindowToMinimum()` | Clamps the window to `contentMinSize`/`contentMaxSize`, per axis. `LoadPreferences()` wraps `open()` so it runs once the autosaved frame is restored. A no-op for windows created without `minSize`/`maxSize`; for windows created **with** them it currently shrinks the window by the title bar height, because vanilla stores those as frame sizes while this compares content sizes |
 
 Both `LoadPreferences()` and `SavePreferences()` automatically call `self.updateUI()` if that method exists — use `updateUI()` to cascade enable/disable state across dependent UI elements.
 
@@ -185,26 +197,28 @@ Both `LoadPreferences()` and `SavePreferences()` automatically call `self.update
 
 Common components and how to use them:
 
+Pass `"auto"` instead of a `posSize` tuple and place them with rules (see below):
+
 ```python
-self.w.label    = vanilla.TextBox((inset, linePos + 2, 120, 14), "Label:", sizeStyle="small", selectable=True)
-self.w.field    = vanilla.EditText((inset + 120, linePos, -inset, 19), "default", callback=self.SavePreferences, sizeStyle="small")
+self.w.label    = vanilla.TextBox("auto", "Label:", sizeStyle="small", selectable=True)
+self.w.field    = vanilla.EditText("auto", "default", callback=self.SavePreferences, sizeStyle="small")
 self.w.field.setToolTip("Tooltip for the field.")
 
-self.w.check    = vanilla.CheckBox((inset, linePos, -inset, 20), "Option", value=True, callback=self.SavePreferences, sizeStyle="small")
+self.w.check    = vanilla.CheckBox("auto", "Option", value=True, callback=self.SavePreferences, sizeStyle="small")
 self.w.check.setToolTip("Tooltip for the checkbox.")
 
-self.w.popup    = vanilla.PopUpButton((inset, linePos, 120, 18), ["A", "B"], callback=self.SavePreferences, sizeStyle="small")
-self.w.combo    = vanilla.ComboBox((inset, linePos, 120, 19), ["A", "B"], callback=self.SavePreferences, sizeStyle="small")
+self.w.popup    = vanilla.PopUpButton("auto", ["A", "B"], callback=self.SavePreferences, sizeStyle="small")
+self.w.combo    = vanilla.ComboBox("auto", ["A", "B"], callback=self.SavePreferences, sizeStyle="small")
 self.w.combo.setToolTip("Tooltip.")
 self.w.combo.getNSComboBox().setNumberOfVisibleItems_(20)
 self.w.combo.getNSComboBox().setFont_(NSFont.userFixedPitchFontOfSize_(11))
 
-self.w.editor   = vanilla.TextEditor((inset, linePos, -inset, 80), "", callback=self.SavePreferences)
+self.w.editor   = vanilla.TextEditor("auto", "", callback=self.SavePreferences)  # give it a height in the rules
 self.w.editor.setToolTip("Multi-line field.")
 
-self.w.divider  = vanilla.HorizontalLine((inset, linePos, -inset, 1))
-self.w.bar      = vanilla.ProgressBar((inset, linePos, -inset, 16))
-self.w.status   = vanilla.TextBox((inset, -28 - inset, -inset - 80, 14), "", sizeStyle="small")
+self.w.divider  = vanilla.HorizontalLine("auto")  # needs an explicit height, e.g. [divider(1)]
+self.w.bar      = vanilla.ProgressBar("auto")
+self.w.status   = vanilla.TextBox("auto", "", sizeStyle="small")
 ```
 
 ### Tooltips
@@ -222,51 +236,107 @@ self.w.myField.setToolTip("Explanation of what this does.")
 self.w.myList.getNSTableView().setToolTip_("Tooltip on the table view.")
 ```
 
-### Layout pattern
+### Window layout — use Auto Layout
+
+Do **not** compute `posSize` frames by hand. Vanilla's frame-based layout inflates a control's
+`posSize` by its `frameAdjustments` — for a push button `(-6, -8, 12, 12)`, hardcoded for the
+classic Aqua bezel. On macOS 26 and later, buttons no longer draw that way, so hardcoded rows
+overlap each other and sit too close to the window edge.
+
+Create every control with `"auto"` and place them with Visual Format Language rules. Auto Layout
+positions *alignment rects* and takes each control's intrinsic content size, so the layout fits
+whatever the running macOS draws, and the insets and gaps are the distances actually seen:
+
+```python
+self.w.addAutoPosSizeRules(
+	[
+		"H:|-inset-[descriptionText]-inset-|",
+		"H:|-inset-[label]-gap-[field]-inset-|",
+		"H:|-inset-[optionA]-gap-[optionB]-(>=inset)-|",
+		"H:|-(>=inset)-[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+		"V:|-gap-[descriptionText]-row-[field]-row-[optionA]-inset-[runButton]-inset-|",
+		"V:[uncheckAllButton]-inset-|",
+		"V:[checkAllButton]-inset-|",
+		{"view1": self.w.label, "attribute1": "centerY", "view2": self.w.field, "attribute2": "centerY"},
+	],
+	metrics={"inset": 15, "gap": 8, "row": 8},
+)
+```
+
+- View names in the rules are the `self.w.<name>` attribute names. Rules may also be dicts
+  (`view1`/`attribute1`/`relation`/`view2`/`attribute2`), which is the only way to express
+  `centerY` alignment or an equal width between two controls.
+- `(>=70)` keeps short button titles from shrinking below the usual push-button width.
+- Guard a right-aligned row with a leading `|-(>=inset)-`, otherwise the chain can run off the
+  left edge when the window is narrow.
+- Put a label on the same baseline as its field with a `centerY` rule, not a `+2` offset.
+- `HorizontalLine` has no intrinsic height — give it one in the rule: `[divider(1)]`.
+- Write one vertical chain per column; equal row heights keep the rows aligned.
+
+**Columns.** Give the cells of a grid one shared width, measured against a single reference
+control, so the columns line up without a hardcoded column offset:
+
+```python
+columnRules = [
+	{"view1": cell, "attribute1": "width", "view2": gridCheckBoxes[0], "attribute2": "width"}
+	for cell in gridCheckBoxes[1:]
+]
+```
+
+**Hugging and compression.** A label next to a flexible control should hug its text, so the
+field or popup takes the leftover width. Where two labels share a width, also make them resist
+compression, otherwise the pair settles below the wider intrinsic width and wraps:
+
+```python
+nsLabel.setContentHuggingPriority_forOrientation_(NSLayoutPriorityDefaultHigh, NSLayoutConstraintOrientationHorizontal)
+nsLabel.setContentCompressionResistancePriority_forOrientation_(NSLayoutPriorityRequired, NSLayoutConstraintOrientationHorizontal)
+```
+
+Keep labels on one line. A block that has to wrap needs a fixed height in the rules plus a
+lowered horizontal compression resistance, so it takes the width it is given instead of
+demanding one long line.
+
+### Letting Auto Layout size the window
+
+Pass **no** `minSize`/`maxSize`. Vanilla adds `NSResizableWindowMask` only when one of them is
+given, and only then calls `setMinSize_`/`setMaxSize_` — which take *frame* sizes, while
+`getPosSize()` and `resizeWindowToMinimum()` work in *content* sizes, so the title bar gets
+counted twice and the window opens shorter than declared. Without them the window stays
+fixed-size, `resizeWindowToMinimum()` becomes a no-op, and AppKit restores only the position
+from the autosaved frame, not the size.
+
+For the window to take its height from the content, two things must hold:
+
+1. **No flexible gap in the vertical chain.** A `-(>=row)-` absorbs any surplus, so the layout
+   has a minimum but no maximum and the window never shrinks.
+2. **Every control hugs vertically** at `NSLayoutPriorityWindowSizeStayPut` (500) — the level at
+   which a constraint starts outranking “keep the window size”. `TextBox`, `Button`, `EditText`,
+   `PopUpButton` and `HorizontalLine` already default to 750, but `CheckBox` and `SquareButton`
+   default to 250 and stretch:
+
+```python
+for view in self.w.getNSWindow().contentView().subviews():
+	view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+```
+
+`windowHeight` is then only a starting value — AppKit grows the window when the content needs
+more and shrinks it when it needs less. Use `1`, not `0`: vanilla treats a zero height specially
+and the window comes out full-screen tall. Widths are still taken from `windowWidth`; hugging
+horizontally at the same level would shrink each window to its widest row and collapse the
+labels that are meant to stretch across the full width.
+
+### Frame-based layout (existing scripts)
+
+Most scripts still place controls with `posSize` tuples and a running `linePos`:
 
 ```python
 linePos, inset, lineHeight = 12, 15, 22
-
-# Place elements, then advance:
 self.w.someElement = vanilla.TextBox((inset, linePos + 2, -inset, 14), "Text", sizeStyle="small")
 linePos += lineHeight
 ```
 
 Negative coordinates are measured from the right/bottom edge (`-inset` = inset from right).
-
-### Bottom button rows — use Auto Layout
-
-Do **not** give the bottom buttons hardcoded `posSize` frames. Vanilla's frame-based layout
-inflates a button's `posSize` by `Button.frameAdjustments = (-6, -8, 12, 12)`, a compensation
-hardcoded for the classic Aqua bezel. On macOS 26 and later, buttons no longer draw that way,
-so hardcoded rows overlap each other and sit too close to the window edge.
-
-Give the buttons `"auto"` instead and place them with Visual Format Language rules. Auto Layout
-takes each button's intrinsic content size, so the row fits whatever the running macOS draws:
-
-```python
-self.w.uncheckAllButton = vanilla.Button("auto", "Uncheck All", callback=self.checkAll)
-self.w.checkAllButton = vanilla.Button("auto", "Check All", callback=self.checkAll)
-self.w.runButton = vanilla.Button("auto", "Build", callback=self.BuildSymbolsMain)
-self.w.setDefaultButton(self.w.runButton)
-self.w.addAutoPosSizeRules(
-	[
-		"H:[uncheckAllButton(>=70)]-gap-[checkAllButton(>=70)]-gap-[runButton(>=70)]-inset-|",
-		"V:[uncheckAllButton]-inset-|",
-		"V:[checkAllButton]-inset-|",
-		"V:[runButton]-inset-|",
-	],
-	metrics={"inset": inset, "gap": 10},
-)
-```
-
-- The view names in the rules are the `self.w.<name>` attribute names.
-- Omitting the leading `|` anchors the chain to the right edge only, so the row stays
-  right-aligned and every button keeps its natural width.
-- For a split row, anchor both edges and let the middle gap flex:
-  `"H:|-inset-[editSinglesButton(>=70)]-(>=gap)-[updateButton(>=70)]-gap-[buildButton(>=70)]-inset-|"`
-- `(>=70)` keeps short titles from shrinking below the usual push-button width.
-- One `V:` rule per button pins it to the bottom edge; its height comes from the system.
+Read it, but prefer Auto Layout for new windows and when reworking an existing one.
 
 ## Shared Utility Functions (`__init__.py`)
 
@@ -280,7 +350,7 @@ self.w.addAutoPosSizeRules(
 | `newLineControlLayer()` | Returns a newline `GSControlLayer` for `tab.layers`; use instead of `GSControlLayer.newline()`, which raises a `TypeError` in some Glyphs versions |
 | `newGlyphWithName(glyphName)` | Returns a new `GSGlyph` with that name; use instead of `GSGlyph(glyphName)`, which raises a `TypeError` in some Glyphs versions |
 | `getLegibleFont(size=None)` | Returns a system legible font (Glyphs 2/3 compatible) |
-| `UpdateButton(posSize, callback, title="")` | Creates a refresh button with an NSRefreshTemplate icon |
+| `UpdateButton(posSize, callback, title="")` | Creates a refresh button with an NSRefreshTemplate icon; `posSize` may be `"auto"` |
 
 ### `caseDict` (Glyphs 3 only)
 

--- a/Components/Alignment Manager.py
+++ b/Components/Alignment Manager.py
@@ -7,7 +7,7 @@ Manage Automatic Alignment for (multiple) selected glyphs.
 
 import vanilla
 from GlyphsApp import Glyphs
-from mekkablue import alignButtonsRight, mekkaObject
+from mekkablue import mekkaObject
 
 
 class AutoAlignmentManager(mekkaObject):
@@ -61,9 +61,6 @@ class AutoAlignmentManager(mekkaObject):
 		self.w.disableButton.setToolTip("Disables automatic alignment with the current span and settings.")
 		self.w.rotateButton = vanilla.Button((-290 - inset, -20 - inset, -200 - inset, -inset), "🔄 Rotate", callback=self.rotateComponents)
 		self.w.rotateButton.setToolTip("Moves the last component into first place. Useful if you quickly want to fix component order without leaving he script UI.")
-
-		# fit the button row to the button metrics of the running macOS version:
-		alignButtonsRight(self.w, (self.w.rotateButton, self.w.disableButton, self.w.enableButton), inset=inset)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Components/Alignment Manager.py
+++ b/Components/Alignment Manager.py
@@ -8,6 +8,7 @@ Manage Automatic Alignment for (multiple) selected glyphs.
 import vanilla
 from GlyphsApp import Glyphs
 from mekkablue import mekkaObject
+from AppKit import NSLayoutConstraintOrientationHorizontal, NSLayoutPriorityDefaultHigh, NSLayoutConstraintOrientationVertical, NSLayoutPriorityWindowSizeStayPut
 
 
 class AutoAlignmentManager(mekkaObject):
@@ -20,8 +21,8 @@ class AutoAlignmentManager(mekkaObject):
 
 	def __init__(self):
 		# Window 'self.w':
-		windowWidth = 350
-		windowHeight = 162
+		windowWidth = 376
+		windowHeight = 1  # Auto Layout grows the window to the required size
 		self.w = vanilla.FloatingWindow(
 			(windowWidth, windowHeight),  # default window size
 			"Alignment Manager",  # window title
@@ -29,30 +30,25 @@ class AutoAlignmentManager(mekkaObject):
 		)
 
 		# UI elements:
-		linePos, inset, lineHeight = 12, 15, 22
+		inset = 15
 
-		self.w.descriptionText = vanilla.TextBox((inset, linePos + 2, -inset, 14), "Manage component alignment in selected glyphs:", sizeStyle="small", selectable=True)
-		linePos += lineHeight
+		self.w.descriptionText = vanilla.TextBox("auto", "Manage component alignment in selected glyphs:", sizeStyle="small", selectable=True)
 
-		self.w.includeAllGlyphs = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "⚠️ Apply to ALL glyphs in font, i.e., ignore glyph selection", value=False, callback=self.SavePreferences, sizeStyle="small")
+		self.w.includeAllGlyphs = vanilla.CheckBox("auto", "⚠️ Apply to ALL glyphs in font, i.e., ignore glyph selection", value=False, callback=self.SavePreferences, sizeStyle="small")
 		self.w.includeAllGlyphs.setToolTip("No matter what your glyph selection is, will enable/disable component alignment for ALL glyphs in the font.")
-		linePos += lineHeight
 
-		self.w.includeAllLayers = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "Include all masters and special layers (recommended)", value=True, callback=self.SavePreferences, sizeStyle="small")
+		self.w.includeAllLayers = vanilla.CheckBox("auto", "Include all masters and special layers (recommended)", value=True, callback=self.SavePreferences, sizeStyle="small")
 		self.w.includeAllLayers.setToolTip("If enabled, will enable/disable automatic alignment not only for the currently selected masters/layers, but for ALL master layers, brace layers and bracket layers of selected glyphs. Will still ignore backup layers (the ones with a timestamp in their names).")
-		linePos += lineHeight
 
-		self.w.differentiationText = vanilla.TextBox((inset, linePos + 2, 75, 14), "Differentiate:", sizeStyle="small", selectable=True)
-		self.w.differentiation = vanilla.PopUpButton((inset + 75, linePos, -inset, 17), ("Treat all components equally", "Ignore first component", "Only apply to first component"), sizeStyle="small", callback=self.SavePreferences)
+		self.w.differentiationText = vanilla.TextBox("auto", "Differentiate:", sizeStyle="small", selectable=True)
+		self.w.differentiation = vanilla.PopUpButton("auto", ("Treat all components equally", "Ignore first component", "Only apply to first component"), sizeStyle="small", callback=self.SavePreferences)
 		self.w.differentiation.setToolTip("You can choose to exclude the first component (usually the base letter) from toggling auto-alignment. This can be useful if you want to keep the diacritic marks aligned to the base, but still move the base. Or if you want to keep the base letter aligned, and place the marks freely.")
-		linePos += lineHeight
 
-		self.w.alignVertical = vanilla.SquareButton((inset, linePos, 20, 18), "↕", sizeStyle="small", callback=self.AutoAlignmentManagerMain)
+		self.w.alignVertical = vanilla.SquareButton("auto", "↕", sizeStyle="small", callback=self.AutoAlignmentManagerMain)
 		self.w.alignVertical.setToolTip("Vertical align: aligns the component, but makes it shiftable in the italic angle.")
-		self.w.alignFull = vanilla.SquareButton((inset + 25, linePos, 20, 18), "☯", sizeStyle="small", callback=self.AutoAlignmentManagerMain)
+		self.w.alignFull = vanilla.SquareButton("auto", "☯", sizeStyle="small", callback=self.AutoAlignmentManagerMain)
 		self.w.alignFull.setToolTip("Full align: aligns the component according to base glyph position and/or anchors.")
-		self.w.alignmentTypeText = vanilla.TextBox((inset + 50, linePos + 2, -inset, 14), "Quick change for selected components: alignment type", sizeStyle="small", selectable=True)
-		linePos += lineHeight
+		self.w.alignmentTypeText = vanilla.TextBox("auto", "Quick change for selected components: alignment type", sizeStyle="small", selectable=True)
 
 		# Run Button:
 		self.w.enableButton = vanilla.Button("auto", "✅ Enable", callback=self.AutoAlignmentManagerMain)
@@ -61,14 +57,35 @@ class AutoAlignmentManager(mekkaObject):
 		self.w.disableButton.setToolTip("Disables automatic alignment with the current span and settings.")
 		self.w.rotateButton = vanilla.Button("auto", "🔄 Rotate", callback=self.rotateComponents)
 		self.w.rotateButton.setToolTip("Moves the last component into first place. Useful if you quickly want to fix component order without leaving he script UI.")
+
+		# a label next to a flexible control hugs its text, so the control gets the leftover width:
+		self.w.differentiationText.getNSTextField().setContentHuggingPriority_forOrientation_(NSLayoutPriorityDefaultHigh, NSLayoutConstraintOrientationHorizontal)
+
+		# checkboxes and square buttons do not resist vertical stretching by default; with
+		# every control hugging vertically and no flexible gap in the chain, the window ends
+		# up exactly as tall as Auto Layout needs. NSLayoutPriorityWindowSizeStayPut (500) is
+		# the level at which a constraint starts outranking "keep the window size".
+		for view in self.w.getNSWindow().contentView().subviews():
+			view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+
 		self.w.addAutoPosSizeRules(
 			[
-				"H:[rotateButton(>=70)]-gap-[disableButton(>=70)]-gap-[enableButton(>=70)]-inset-|",
+				"H:|-inset-[descriptionText]-inset-|",
+				"H:|-inset-[includeAllGlyphs]-inset-|",
+				"H:|-inset-[includeAllLayers]-inset-|",
+				"H:|-inset-[differentiationText]-[differentiation]-inset-|",
+				"H:|-inset-[alignVertical(20)]-gap-[alignFull(20)]-gap-[alignmentTypeText]-inset-|",
+				"H:|-(>=inset)-[rotateButton(>=70)]-gap-[disableButton(>=70)]-gap-[enableButton(>=70)]-inset-|",
+				"V:|-gap-[descriptionText]-line-[includeAllGlyphs]-line-[includeAllLayers]-line-[differentiation]-line-[alignVertical(18)]-inset-[enableButton]-inset-|",
+				"V:[alignFull(18)]",
 				"V:[rotateButton]-inset-|",
 				"V:[disableButton]-inset-|",
-				"V:[enableButton]-inset-|",
+				# labels ride along with the control they belong to:
+				{"view1": self.w.differentiationText, "attribute1": "centerY", "view2": self.w.differentiation, "attribute2": "centerY"},
+				{"view1": self.w.alignFull, "attribute1": "centerY", "view2": self.w.alignVertical, "attribute2": "centerY"},
+				{"view1": self.w.alignmentTypeText, "attribute1": "centerY", "view2": self.w.alignVertical, "attribute2": "centerY"},
 			],
-			metrics={"inset": inset, "gap": 10},
+			metrics={"inset": inset, "gap": 8, "line": 8},
 		)
 
 		# Load Settings:

--- a/Components/Alignment Manager.py
+++ b/Components/Alignment Manager.py
@@ -55,12 +55,21 @@ class AutoAlignmentManager(mekkaObject):
 		linePos += lineHeight
 
 		# Run Button:
-		self.w.enableButton = vanilla.Button((-90 - inset, -20 - inset, -inset, -inset), "✅ Enable", callback=self.AutoAlignmentManagerMain)
+		self.w.enableButton = vanilla.Button("auto", "✅ Enable", callback=self.AutoAlignmentManagerMain)
 		self.w.enableButton.setToolTip("Enables automatic alignment with the current span and settings.")
-		self.w.disableButton = vanilla.Button((-190 - inset, -20 - inset, -100 - inset, -inset), "🚫 Disable", callback=self.AutoAlignmentManagerMain)
+		self.w.disableButton = vanilla.Button("auto", "🚫 Disable", callback=self.AutoAlignmentManagerMain)
 		self.w.disableButton.setToolTip("Disables automatic alignment with the current span and settings.")
-		self.w.rotateButton = vanilla.Button((-290 - inset, -20 - inset, -200 - inset, -inset), "🔄 Rotate", callback=self.rotateComponents)
+		self.w.rotateButton = vanilla.Button("auto", "🔄 Rotate", callback=self.rotateComponents)
 		self.w.rotateButton.setToolTip("Moves the last component into first place. Useful if you quickly want to fix component order without leaving he script UI.")
+		self.w.addAutoPosSizeRules(
+			[
+				"H:[rotateButton(>=70)]-gap-[disableButton(>=70)]-gap-[enableButton(>=70)]-inset-|",
+				"V:[rotateButton]-inset-|",
+				"V:[disableButton]-inset-|",
+				"V:[enableButton]-inset-|",
+			],
+			metrics={"inset": inset, "gap": 10},
+		)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Components/Populate Backgrounds with Components.py
+++ b/Components/Populate Backgrounds with Components.py
@@ -6,7 +6,7 @@ Adds a component to all backgrounds of all layers of all selected glyphs. Useful
 """
 
 import vanilla
-from AppKit import NSEvent
+from AppKit import NSEvent, NSLayoutConstraintOrientationVertical, NSLayoutPriorityWindowSizeStayPut
 from GlyphsApp import Glyphs, GSComponent, Message
 from mekkablue import mekkaObject, UpdateButton
 from mekkablue.geometry import transform
@@ -22,37 +22,31 @@ class PopulateAllBackgroundswithComponent(mekkaObject):
 	def __init__(self):
 		# Window 'self.w':
 		windowWidth = 380
-		windowHeight = 155
-		windowWidthResize = 300  # user can resize width by this value
-		windowHeightResize = 0  # user can resize height by this value
+		windowHeight = 1  # Auto Layout grows the window to the required size
+		# no minSize/maxSize: that keeps the window unresizable, and keeps the size limits
+		# out of Auto Layout's way
 		self.w = vanilla.FloatingWindow(
 			(windowWidth, windowHeight),  # default window size
 			"Populate Layer Backgrounds with Component",  # window title
-			minSize=(windowWidth - 10, windowHeight),  # minimum size (for resizing)
-			maxSize=(windowWidth + windowWidthResize, windowHeight + windowHeightResize),  # maximum size (for resizing)
 			autosaveName=self.domain("mainwindow")  # stores last window position and size
 		)
 
 		# UI elements:
-		linePos, inset, lineHeight = 10, 15, 22
+		inset = 15
 
-		self.w.descriptionText = vanilla.TextBox((inset, linePos + 2, -inset, 14), "In selected glyphs, insert component in all layer backgrounds:", sizeStyle='small', selectable=True)
-		linePos += lineHeight
+		self.w.descriptionText = vanilla.TextBox("auto", "In selected glyphs, insert component in all layer backgrounds:", sizeStyle='small', selectable=True)
 
-		self.w.text_1 = vanilla.TextBox((inset - 1, linePos + 2, 100, 14), "Add component:", sizeStyle='small')
-		self.w.componentName = vanilla.EditText((inset + 92, linePos - 1, -inset - 25, 19), "a", sizeStyle='small', callback=self.SavePreferences)
+		self.w.text_1 = vanilla.TextBox("auto", "Add component:", sizeStyle='small')
+		self.w.componentName = vanilla.EditText("auto", "a", sizeStyle='small', callback=self.SavePreferences)
 		self.w.componentName.setToolTip("Name of the glyph that should be inserted as component in the background of all layers of the selected glyph(s).")
-		self.w.updateButton = UpdateButton((-inset - 18, linePos - 2, -inset, 18), callback=self.update)
+		self.w.updateButton = UpdateButton("auto", callback=self.update)
 		self.w.updateButton.setToolTip("Guess the component name. Hold down OPTION to ignore the suffix.")
-		linePos += lineHeight
 
-		self.w.alignRight = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "Align with right edge of layer", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.alignRight = vanilla.CheckBox("auto", "Align with right edge of layer", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.alignRight.setToolTip("Right-aligns the component width with the layer width. Useful for the e in ae or oe, for example.")
-		linePos += lineHeight
 
-		self.w.replaceBackgrounds = vanilla.CheckBox((inset + 2, linePos - 1, -inset, 20), "Replace existing backgrounds", value=False, callback=self.SavePreferences, sizeStyle='small')
+		self.w.replaceBackgrounds = vanilla.CheckBox("auto", "Replace existing backgrounds", value=False, callback=self.SavePreferences, sizeStyle='small')
 		self.w.replaceBackgrounds.setToolTip("Deletes existing background content before it inserts the component. Recommended if you want to align selected nodes with the background.")
-		linePos += lineHeight
 
 		# Run Button:
 		self.w.runButton = vanilla.Button("auto", "Populate", callback=self.PopulateAllBackgroundswithComponentMain)
@@ -64,14 +58,30 @@ class PopulateAllBackgroundswithComponent(mekkaObject):
 
 		self.w.nextMasterButton = vanilla.Button("auto", "Next Master", callback=self.NextMasterMain)
 		self.w.nextMasterButton.setToolTip("Switches the current tab to the next master. Useful if you want to align the same nodes in every master.")
+
+		# checkboxes and square buttons do not resist vertical stretching by default; with
+		# every control hugging vertically and no flexible gap in the chain, the window ends
+		# up exactly as tall as Auto Layout needs. NSLayoutPriorityWindowSizeStayPut (500) is
+		# the level at which a constraint starts outranking "keep the window size".
+		for view in self.w.getNSWindow().contentView().subviews():
+			view.setContentHuggingPriority_forOrientation_(NSLayoutPriorityWindowSizeStayPut, NSLayoutConstraintOrientationVertical)
+
 		self.w.addAutoPosSizeRules(
 			[
-				"H:[nextMasterButton(>=70)]-gap-[alignButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"H:|-inset-[descriptionText]-inset-|",
+				"H:|-inset-[text_1]-gap-[componentName]-gap-[updateButton(18)]-inset-|",
+				"H:|-inset-[alignRight]-inset-|",
+				"H:|-inset-[replaceBackgrounds]-inset-|",
+				"H:|-(>=inset)-[nextMasterButton(>=70)]-gap-[alignButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"V:|-gap-[descriptionText]-line-[componentName]-line-[alignRight]-line-[replaceBackgrounds]-inset-[runButton]-inset-|",
+				"V:[updateButton(18)]",
 				"V:[nextMasterButton]-inset-|",
 				"V:[alignButton]-inset-|",
-				"V:[runButton]-inset-|",
+				# label and update button ride along with the text field:
+				{"view1": self.w.text_1, "attribute1": "centerY", "view2": self.w.componentName, "attribute2": "centerY"},
+				{"view1": self.w.updateButton, "attribute1": "centerY", "view2": self.w.componentName, "attribute2": "centerY"},
 			],
-			metrics={"inset": inset, "gap": 10},
+			metrics={"inset": inset, "gap": 8, "line": 8},
 		)
 
 		# Load Settings:

--- a/Components/Populate Backgrounds with Components.py
+++ b/Components/Populate Backgrounds with Components.py
@@ -55,15 +55,24 @@ class PopulateAllBackgroundswithComponent(mekkaObject):
 		linePos += lineHeight
 
 		# Run Button:
-		self.w.runButton = vanilla.Button((-100 - inset, -20 - inset, -inset, -inset), "Populate", callback=self.PopulateAllBackgroundswithComponentMain)
+		self.w.runButton = vanilla.Button("auto", "Populate", callback=self.PopulateAllBackgroundswithComponentMain)
 		self.w.runButton.setToolTip("Inserts the specified component in ALL layers of the current glyph(s).")
 		self.w.setDefaultButton(self.w.runButton)
 
-		self.w.alignButton = vanilla.Button((-220 - inset, -20 - inset, -110 - inset, -inset), "Align Nodes", callback=self.AlignNodesMain)
+		self.w.alignButton = vanilla.Button("auto", "Align Nodes", callback=self.AlignNodesMain)
 		self.w.alignButton.setToolTip("Aligns selected nodes with the (original) nodes in the background components. Only does this on the CURRENT layer.")
 
-		self.w.nextMasterButton = vanilla.Button((-340 - inset, -20 - inset, -230 - inset, -inset), "Next Master", callback=self.NextMasterMain)
+		self.w.nextMasterButton = vanilla.Button("auto", "Next Master", callback=self.NextMasterMain)
 		self.w.nextMasterButton.setToolTip("Switches the current tab to the next master. Useful if you want to align the same nodes in every master.")
+		self.w.addAutoPosSizeRules(
+			[
+				"H:[nextMasterButton(>=70)]-gap-[alignButton(>=70)]-gap-[runButton(>=70)]-inset-|",
+				"V:[nextMasterButton]-inset-|",
+				"V:[alignButton]-inset-|",
+				"V:[runButton]-inset-|",
+			],
+			metrics={"inset": inset, "gap": 10},
+		)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/Components/Populate Backgrounds with Components.py
+++ b/Components/Populate Backgrounds with Components.py
@@ -8,7 +8,7 @@ Adds a component to all backgrounds of all layers of all selected glyphs. Useful
 import vanilla
 from AppKit import NSEvent
 from GlyphsApp import Glyphs, GSComponent, Message
-from mekkablue import alignButtonsRight, mekkaObject, UpdateButton
+from mekkablue import mekkaObject, UpdateButton
 from mekkablue.geometry import transform
 
 
@@ -64,9 +64,6 @@ class PopulateAllBackgroundswithComponent(mekkaObject):
 
 		self.w.nextMasterButton = vanilla.Button((-340 - inset, -20 - inset, -230 - inset, -inset), "Next Master", callback=self.NextMasterMain)
 		self.w.nextMasterButton.setToolTip("Switches the current tab to the next master. Useful if you want to align the same nodes in every master.")
-
-		# fit the button row to the button metrics of the running macOS version:
-		alignButtonsRight(self.w, (self.w.nextMasterButton, self.w.alignButton, self.w.runButton), inset=inset)
 
 		# Load Settings:
 		self.LoadPreferences()

--- a/__init__.py
+++ b/__init__.py
@@ -283,73 +283,34 @@ def UpdateButton(posSize, callback, title=""):
 	return button
 
 
-def measureButtons(buttons, minButtonWidth=70, minHeight=20):
+def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
 	"""
-	Measures the sizes vanilla Buttons need on the running system.
-	Returns (widths, height): a list with one width per button, and the height
-	of the tallest one. Sizes are taken from the button cells, so they follow
-	the button metrics of the macOS version the script is running on.
-	"""
-	widths = []
-	height = minHeight
-	for button in buttons:
-		nsButton = button.getNSButton()
-		nsButton.sizeToFit()
-		sizes = [nsButton.fittingSize(), nsButton.frame().size]
-		try:
-			sizes.append(nsButton.cell().cellSize())
-			sizes.append(nsButton.intrinsicContentSize())
-		except:
-			pass
-		widths.append(max(minButtonWidth, ceil(max(size.width for size in sizes))))
-		height = max(height, ceil(max(size.height for size in sizes)))
-	return widths, height
-
-
-def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, leftGap=None, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
-	"""
-	Lays out one or two groups of vanilla Buttons along the bottom edge of window:
-	rightButtons are right-aligned, leftButtons are left-aligned. Each button gets
-	the size it actually needs on the running system, rather than a hardcoded one.
-	Necessary because push buttons became larger in recent macOS versions, which
-	made hardcoded button rows collide.
-	Recent macOS also draws the button bezel *beyond* the button frame. The overhang
-	is derived from how much taller the buttons are than assumedHeight, and added to
-	the gaps and the window edge distances, so that the drawn (not the theoretical)
-	buttons keep their distances. On older macOS, the overhang is zero and the layout
-	is the same as before.
+	Lays out a row of vanilla Buttons right-aligned along the bottom edge of window.
+	Each button gets the width and height it actually needs on the running system,
+	rather than a hardcoded size. Necessary because push buttons became wider and
+	taller in recent macOS versions, which made hardcoded button rows overlap.
 	window: the vanilla window containing the buttons,
-	rightButtons: the vanilla Buttons for the bottom right, in left-to-right order,
-	leftButtons: the vanilla Buttons for the bottom left, in left-to-right order,
-	inset: distance to the window edges,
-	gap: visible horizontal distance between two buttons,
-	leftGap: same, but for the leftButtons group only; defaults to gap,
+	buttons: the vanilla Buttons, in left-to-right order,
+	inset: distance to the right and bottom window edges,
+	gap: horizontal distance between two buttons,
 	minButtonWidth: no button will be narrower than this,
 	assumedHeight: the button height the rest of the window layout was built for,
 	resizeWindow: if True, grows the window (and its size constraints) to fit the row.
 	Returns (rowWidth, rowHeight), or None if the measurement failed.
 	"""
 	try:
-		if leftGap is None:
-			leftGap = gap
-		rightWidths, height = measureButtons(rightButtons, minButtonWidth, assumedHeight)
-		leftWidths, height = measureButtons(leftButtons, minButtonWidth, height)
+		widths = []
+		height = assumedHeight
+		for button in buttons:
+			nsButton = button.getNSButton()
+			nsButton.sizeToFit()
+			fittingSize = nsButton.fittingSize()
+			frameSize = nsButton.frame().size
+			widths.append(max(minButtonWidth, ceil(max(fittingSize.width, frameSize.width))))
+			height = max(height, ceil(max(fittingSize.height, frameSize.height)))
 
-		# how far the drawn bezel extends beyond the button frame on each side:
-		overhang = max(0, (height - assumedHeight) // 2)
-		bottomInset = inset + overhang
-		sideInset = inset + overhang
-		rightStep = gap + 2 * overhang  # frame distance yielding a visible distance of gap
-		leftStep = leftGap + 2 * overhang
-
-		rowWidth = sum(rightWidths) + sum(leftWidths) + 2 * overhang
-		if rightWidths:
-			rowWidth += rightStep * (len(rightWidths) - 1)
-		if leftWidths:
-			rowWidth += leftStep * (len(leftWidths) - 1)
-		if rightWidths and leftWidths:
-			rowWidth += rightStep  # minimum distance between the two groups
-		rowHeight = height + 2 * overhang
+		rowWidth = sum(widths) + gap * (len(buttons) - 1)
+		rowHeight = height
 
 		if resizeWindow:
 			windowWidth, windowHeight = window.getPosSize()[2], window.getPosSize()[3]
@@ -365,17 +326,11 @@ def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, left
 					setter(NSMakeSize(currentSize.width + deltaWidth, currentSize.height + deltaHeight))
 				window.resize(windowWidth + deltaWidth, windowHeight + deltaHeight, animate=False)
 
-		# right group, positioned right to left:
-		rightEdge = sideInset
-		for button, width in zip(reversed(rightButtons), reversed(rightWidths)):
-			button.setPosSize((-rightEdge - width, -height - bottomInset, width, height))
-			rightEdge += width + rightStep
-
-		# left group, positioned left to right:
-		leftEdge = sideInset
-		for button, width in zip(leftButtons, leftWidths):
-			button.setPosSize((leftEdge, -height - bottomInset, width, height))
-			leftEdge += width + leftStep
+		# position right to left:
+		rightEdge = inset
+		for button, width in zip(reversed(buttons), reversed(widths)):
+			button.setPosSize((-rightEdge - width, -rowHeight - inset, width, rowHeight))
+			rightEdge += width + gap
 
 		return rowWidth, rowHeight
 	except:
@@ -383,22 +338,6 @@ def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, left
 		print(traceback.format_exc())
 		print("⚠️ Could not align buttons, will resort to their original positions.")
 		return None
-
-
-def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
-	"""
-	Lays out a row of vanilla Buttons right-aligned along the bottom edge of window.
-	Shortcut for alignButtons() with a right group only; see there for details.
-	"""
-	return alignButtons(
-		window,
-		rightButtons=buttons,
-		inset=inset,
-		gap=gap,
-		minButtonWidth=minButtonWidth,
-		assumedHeight=assumedHeight,
-		resizeWindow=resizeWindow,
-	)
 
 
 def updatedCode(oldCode, beginSig, endSig, newCode):

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,6 @@
 from math import ceil
 from typing import Any
 from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSMakeSize, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
-from Foundation import NSProcessInfo
 from GlyphsApp import Glyphs, GSFeature, GSClass, GSControlLayer, GSGlyph
 from vanilla import Button
 
@@ -284,31 +283,6 @@ def UpdateButton(posSize, callback, title=""):
 	return button
 
 
-# On macOS 26 (Tahoe) and later, a push button is *drawn* larger than the frame it is
-# given: roughly this tall, no matter whether the frame is 20 or 22 points high, and
-# correspondingly wider. These are the values the layout compensates with:
-tahoeDrawnButtonHeight = 32
-tahoeMinimumOverhang = 2
-
-
-def systemButtonMetrics(assumedHeight=20):
-	"""
-	Returns (drawnButtonHeight, minimumOverhang) for the macOS version we are running on.
-	drawnButtonHeight is how tall a push button ends up on screen; the layout derives the
-	bezel overhang (how far the button is drawn beyond its frame) from the difference to
-	the actual button frame. Hardcoded per system version on purpose: measuring alone is
-	not enough, because the button cells can still report the legacy (smaller) sizes
-	although the button is drawn larger.
-	"""
-	try:
-		majorVersion = NSProcessInfo.processInfo().operatingSystemVersion().majorVersion
-	except:
-		majorVersion = 0
-	if majorVersion >= 26:
-		return max(assumedHeight, tahoeDrawnButtonHeight), tahoeMinimumOverhang
-	return assumedHeight, 0
-
-
 def measureButtons(buttons, minButtonWidth=70, minHeight=20):
 	"""
 	Measures the sizes vanilla Buttons need on the running system.
@@ -332,17 +306,18 @@ def measureButtons(buttons, minButtonWidth=70, minHeight=20):
 	return widths, height
 
 
-def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, leftGap=None, minButtonWidth=70, assumedHeight=20, spaceAbove=5, resizeWindow=True):
+def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, leftGap=None, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
 	"""
 	Lays out one or two groups of vanilla Buttons along the bottom edge of window:
 	rightButtons are right-aligned, leftButtons are left-aligned. Each button gets
 	the size it actually needs on the running system, rather than a hardcoded one.
 	Necessary because push buttons became larger in recent macOS versions, which
 	made hardcoded button rows collide.
-	Recent macOS also draws the button bezel *beyond* the button frame. That overhang
-	(see systemButtonMetrics()) is added to the gaps and to the window edge distances,
-	so that the drawn (not the theoretical) buttons keep their distances. On older
-	macOS, the overhang is zero and the layout is the same as before.
+	Recent macOS also draws the button bezel *beyond* the button frame. The overhang
+	is derived from how much taller the buttons are than assumedHeight, and added to
+	the gaps and the window edge distances, so that the drawn (not the theoretical)
+	buttons keep their distances. On older macOS, the overhang is zero and the layout
+	is the same as before.
 	window: the vanilla window containing the buttons,
 	rightButtons: the vanilla Buttons for the bottom right, in left-to-right order,
 	leftButtons: the vanilla Buttons for the bottom left, in left-to-right order,
@@ -351,19 +326,17 @@ def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, left
 	leftGap: same, but for the leftButtons group only; defaults to gap,
 	minButtonWidth: no button will be narrower than this,
 	assumedHeight: the button height the rest of the window layout was built for,
-	spaceAbove: extra window height, so the row has more breathing space above it,
 	resizeWindow: if True, grows the window (and its size constraints) to fit the row.
 	Returns (rowWidth, rowHeight), or None if the measurement failed.
 	"""
 	try:
 		if leftGap is None:
 			leftGap = gap
-		drawnHeight, minOverhang = systemButtonMetrics(assumedHeight)
 		rightWidths, height = measureButtons(rightButtons, minButtonWidth, assumedHeight)
 		leftWidths, height = measureButtons(leftButtons, minButtonWidth, height)
 
 		# how far the drawn bezel extends beyond the button frame on each side:
-		overhang = max(minOverhang, ceil((drawnHeight - height) / 2))
+		overhang = max(0, (height - assumedHeight) // 2)
 		bottomInset = inset + overhang
 		sideInset = inset + overhang
 		rightStep = gap + 2 * overhang  # frame distance yielding a visible distance of gap
@@ -381,7 +354,7 @@ def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, left
 		if resizeWindow:
 			windowWidth, windowHeight = window.getPosSize()[2], window.getPosSize()[3]
 			deltaWidth = max(0, rowWidth + 2 * inset - windowWidth)
-			deltaHeight = max(0, rowHeight - assumedHeight) + spaceAbove
+			deltaHeight = max(0, rowHeight - assumedHeight)
 			if deltaWidth or deltaHeight:
 				nsWindow = window._window
 				for getter, setter in (
@@ -412,7 +385,7 @@ def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, left
 		return None
 
 
-def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assumedHeight=20, spaceAbove=5, resizeWindow=True):
+def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
 	"""
 	Lays out a row of vanilla Buttons right-aligned along the bottom edge of window.
 	Shortcut for alignButtons() with a right group only; see there for details.
@@ -424,7 +397,6 @@ def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assu
 		gap=gap,
 		minButtonWidth=minButtonWidth,
 		assumedHeight=assumedHeight,
-		spaceAbove=spaceAbove,
 		resizeWindow=resizeWindow,
 	)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,6 @@
 
-from math import ceil
 from typing import Any
-from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSMakeSize, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
+from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
 from GlyphsApp import Glyphs, GSFeature, GSClass, GSControlLayer, GSGlyph
 from vanilla import Button
 
@@ -281,63 +280,6 @@ def UpdateButton(posSize, callback, title=""):
 		button.getNSButton().setImagePosition_(NSImageLeading)
 	button.getNSButton().setBordered_(False)
 	return button
-
-
-def alignButtonsRight(window, buttons, inset=15, gap=10, minButtonWidth=70, assumedHeight=20, resizeWindow=True):
-	"""
-	Lays out a row of vanilla Buttons right-aligned along the bottom edge of window.
-	Each button gets the width and height it actually needs on the running system,
-	rather than a hardcoded size. Necessary because push buttons became wider and
-	taller in recent macOS versions, which made hardcoded button rows overlap.
-	window: the vanilla window containing the buttons,
-	buttons: the vanilla Buttons, in left-to-right order,
-	inset: distance to the right and bottom window edges,
-	gap: horizontal distance between two buttons,
-	minButtonWidth: no button will be narrower than this,
-	assumedHeight: the button height the rest of the window layout was built for,
-	resizeWindow: if True, grows the window (and its size constraints) to fit the row.
-	Returns (rowWidth, rowHeight), or None if the measurement failed.
-	"""
-	try:
-		widths = []
-		height = assumedHeight
-		for button in buttons:
-			nsButton = button.getNSButton()
-			nsButton.sizeToFit()
-			fittingSize = nsButton.fittingSize()
-			frameSize = nsButton.frame().size
-			widths.append(max(minButtonWidth, ceil(max(fittingSize.width, frameSize.width))))
-			height = max(height, ceil(max(fittingSize.height, frameSize.height)))
-
-		rowWidth = sum(widths) + gap * (len(buttons) - 1)
-		rowHeight = height
-
-		if resizeWindow:
-			windowWidth, windowHeight = window.getPosSize()[2], window.getPosSize()[3]
-			deltaWidth = max(0, rowWidth + 2 * inset - windowWidth)
-			deltaHeight = max(0, rowHeight - assumedHeight)
-			if deltaWidth or deltaHeight:
-				nsWindow = window._window
-				for getter, setter in (
-					(nsWindow.contentMinSize, nsWindow.setContentMinSize_),
-					(nsWindow.contentMaxSize, nsWindow.setContentMaxSize_),
-				):
-					currentSize = getter()
-					setter(NSMakeSize(currentSize.width + deltaWidth, currentSize.height + deltaHeight))
-				window.resize(windowWidth + deltaWidth, windowHeight + deltaHeight, animate=False)
-
-		# position right to left:
-		rightEdge = inset
-		for button, width in zip(reversed(buttons), reversed(widths)):
-			button.setPosSize((-rightEdge - width, -rowHeight - inset, width, rowHeight))
-			rightEdge += width + gap
-
-		return rowWidth, rowHeight
-	except:
-		import traceback
-		print(traceback.format_exc())
-		print("⚠️ Could not align buttons, will resort to their original positions.")
-		return None
 
 
 def updatedCode(oldCode, beginSig, endSig, newCode):


### PR DESCRIPTION
Supersedes and reverts #485, #486 and #487.

## Why

On macOS 26 the bottom button rows overlapped each other and sat too close to the window edge. The cause is vanilla's frame-based layout: it inflates every button's `posSize` by `Button.frameAdjustments = (-6, -8, 12, 12)`, a compensation hardcoded for the classic Aqua bezel that modern buttons no longer draw. In Build Symbols the three buttons ended up at x 90–217, 215–327 and 325–417 — two 2pt overlaps, and a 9pt instead of a 15pt distance to the window edge.

#485–#487 tried to compensate by measuring the buttons and adding a version-dependent bezel overhang. That kept fighting the frame-based layout, so those three are reverted (as real revert commits) and the fix is redone with Auto Layout, which derives the metrics from the system instead of hardcoding them.

## What changed

Six windows are now laid out entirely with Auto Layout — every control is created with `posSize="auto"` and placed by Visual Format Language rules, so the `linePos`/`lineHeight` bookkeeping and the hardcoded `posSize` frames are gone:

- `Build Glyphs/Build Symbols.py`
- `Build Glyphs/Build Rare Symbols.py`
- `Build Glyphs/Build Small Figures.py`
- `Build Glyphs/Quote Manager.py`
- `Components/Alignment Manager.py`
- `Components/Populate Backgrounds with Components.py`

No shared helpers were added; `__init__.py` is untouched. `CLAUDE.md` documents the pattern.

Notes on the rules, for review:

- Grid columns share one width, measured against a single reference checkbox, so the columns line up across rows without a hardcoded column offset.
- Labels hug their text and ride along with their control via `centerY` rules instead of hand-tuned `+2`/`+3` offsets.
- The windows size themselves. No `minSize`/`maxSize` is passed, no flexible gap is left in the vertical chains, and every control hugs vertically at `NSLayoutPriorityWindowSizeStayPut` — below that level a constraint does not outrank the window's own size, and `CheckBox`/`SquareButton` default to 250 and would otherwise stretch and swallow the slack.

## Reviewer notes

- **Window sizes changed.** Build Symbols 426x208 → 434x195, Build Rare Symbols 355x328 → 355x343, Build Small Figures 400x212 → 400x230, Quote Manager 360x320 → 320x295, Alignment Manager 350x162 → 376x174, Populate Backgrounds 380x155 → 380x150. The growth buys back space that was being clipped: Alignment Manager's "Quick change for selected components: alignment type" was cut off, and in Populate Backgrounds the button row overlapped the last checkbox by 5pt.
- **Build Small Figures, Quote Manager and Populate Backgrounds are no longer width-resizable**, because that resizability came from the `maxSize` argument. Build Small Figures is the one where the extra width was arguably useful (the Derivatives field holds a long comma-separated list); happy to restore it there.
- **Not fixed here:** `mekkaObject.resizeWindowToMinimum()` shrinks windows by the title bar height whenever a script passes `minSize`/`maxSize`, because vanilla forwards those to `setMinSize_`/`setMaxSize_` (frame sizes) while the clamp compares content sizes. It no longer affects these six, since they pass neither, but it still affects every other GUI script that does.

## Verification

Measured on macOS 26.5.2 against the vanilla that Glyphs 4 actually loads (`Scripts/site-packages`, not the `Repositories` checkout). Each script was loaded against a stubbed GlyphsApp and the laid-out alignment rects were dumped and checked: no overlaps, nothing outside the content view, 15pt above the button row and a 15pt bottom inset in all six. Also verified that the declared `windowHeight` no longer matters (building each window 150pt too tall and 100pt too short yields the same height) and that a stale autosaved frame cannot reintroduce the gap.

`flake8` is clean on all six.