### PR TITLE
Pilot: auto layout for the Build Rare Symbols button row

### DIFF
--- a/Build Glyphs/Build Rare Symbols.py
+++ b/Build Glyphs/Build Rare Symbols.py
@@ -7,7 +7,7 @@ Builds white and black, small and large, circles, triangles and squares.
 
 import vanilla
 from GlyphsApp import Glyphs, GSGlyph, GSLayer, GSComponent, Message
-from mekkablue import alignButtons, mekkaObject, newGlyphWithName
+from mekkablue import autoPosSize, layoutButtonRow, mekkaObject, newGlyphWithName
 from mekkablue.geometry import transform, offsetLayer
 from Foundation import NSPoint
 
@@ -484,19 +484,30 @@ class BuildCirclesSquaresTriangles(mekkaObject):
 		linePos += lineHeight
 
 		# Run Button:
-		self.w.runButton = vanilla.Button((-80 - inset, -20 - inset, -inset, -inset), "Build", callback=self.BuildCirclesSquaresTrianglesMain)
+		self.w.runButton = vanilla.Button(autoPosSize(self.w, (-80 - inset, -20 - inset, -inset, -inset)), "Build", callback=self.BuildCirclesSquaresTrianglesMain)
 		self.w.setDefaultButton(self.w.runButton)
 
 		# (un)check all checkboxes:
-		self.w.checkAllButton = vanilla.Button((-180 - inset, -20 - inset, -90 - inset, -inset), "Check All", callback=self.checkOrUncheckAll)
+		self.w.checkAllButton = vanilla.Button(autoPosSize(self.w, (-180 - inset, -20 - inset, -90 - inset, -inset)), "Check All", callback=self.checkOrUncheckAll)
 		self.w.checkAllButton.setToolTip("Activates all checkboxes above the separator line.")
-		self.w.uncheckAllButton = vanilla.Button((-300 - inset, -20 - inset, -190 - inset, -inset), "Uncheck All", callback=self.checkOrUncheckAll)
+		self.w.uncheckAllButton = vanilla.Button(autoPosSize(self.w, (-300 - inset, -20 - inset, -190 - inset, -inset)), "Uncheck All", callback=self.checkOrUncheckAll)
 		self.w.uncheckAllButton.setToolTip("Deactivates all checkboxes above the separator line.")
 
-		# fit the button row to the button metrics of the running macOS version:
-		# Build in the bottom right corner, the (un)check buttons in the bottom left:
-		alignButtons(
+		# Build in the bottom right corner, the (un)check buttons in the bottom left.
+		# Auto layout keeps the distances between the buttons as macOS draws them:
+		layoutButtonRow(
 			self.w,
+			rules=(
+				"H:|-border-[uncheckAllButton]-tight-[checkAllButton]",
+				"H:[runButton]-border-|",
+				"V:[uncheckAllButton]-border-|",
+				"V:[checkAllButton]-border-|",
+				"V:[runButton]-border-|",
+			),
+			metrics={
+				"border": inset,
+				"tight": 6,
+			},
 			rightButtons=(self.w.runButton, ),
 			leftButtons=(self.w.uncheckAllButton, self.w.checkAllButton),
 			inset=inset,

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 
 from math import ceil
 from typing import Any
-from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSMakeSize, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
+from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSLayoutConstraintOrientationHorizontal, NSLayoutPriorityDefaultHigh, NSMakeSize, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
 from Foundation import NSProcessInfo
 from GlyphsApp import Glyphs, GSFeature, GSClass, GSControlLayer, GSGlyph
 from vanilla import Button
@@ -309,6 +309,108 @@ def systemButtonMetrics(assumedHeight=20):
 	return assumedHeight, 0
 
 
+def growWindow(window, deltaWidth=0, deltaHeight=0):
+	"""
+	Grows the window by the given amounts, and its minimum and maximum sizes with it,
+	so that resizeWindowToMinimum() will not shrink the extra space away again.
+	"""
+	if deltaWidth <= 0 and deltaHeight <= 0:
+		return
+	deltaWidth = max(0, deltaWidth)
+	deltaHeight = max(0, deltaHeight)
+	nsWindow = window._window
+	for getter, setter in (
+		(nsWindow.contentMinSize, nsWindow.setContentMinSize_),
+		(nsWindow.contentMaxSize, nsWindow.setContentMaxSize_),
+	):
+		currentSize = getter()
+		setter(NSMakeSize(currentSize.width + deltaWidth, currentSize.height + deltaHeight))
+	windowWidth, windowHeight = window.getPosSize()[2], window.getPosSize()[3]
+	window.resize(windowWidth + deltaWidth, windowHeight + deltaHeight, animate=False)
+
+
+def supportsAutoLayout(window):
+	"""Returns True if the vanilla we are running with can do auto layout."""
+	return hasattr(window, "addAutoPosSizeRules") and hasattr(window, "_autoLayoutViews")
+
+
+def autoPosSize(window, framePosSize):
+	"""
+	Returns "auto" if window can do auto layout, otherwise the given frame posSize tuple.
+	Use as the posSize of a control that is meant to be laid out with rules, so the
+	script keeps working with vanilla versions that predate auto layout.
+	"""
+	if supportsAutoLayout(window):
+		return "auto"
+	return framePosSize
+
+
+def layoutButtonRow(window, rules, metrics=None, rightButtons=(), leftButtons=(), inset=15, gap=10, leftGap=None, assumedHeight=20, spaceAbove=5):
+	"""
+	Lays out a row of vanilla Buttons along the bottom edge of window with auto layout,
+	and grows the window to make room for the row. The buttons must have been created
+	with autoPosSize(), and the rules must reference them by their attribute names,
+	e.g. "H:|-border-[uncheckAllButton]-tight-[checkAllButton]-(>=space)-[runButton]-border-|".
+	Auto layout positions the buttons by their alignment rects, i.e. macOS itself takes
+	care of the bezel that is drawn beyond the button frame, and of the button sizes.
+	Falls back to alignButtons() if this vanilla cannot do auto layout, in which case
+	the rules are ignored and the buttons keep the frames autoPosSize() gave them.
+	window: the vanilla window containing the buttons,
+	rules: the auto layout rules, see vanilla’s addAutoPosSizeRules(),
+	metrics: the values the rules refer to by name, e.g. {"border": 15},
+	rightButtons, leftButtons: the buttons, only used for the fallback and for measuring,
+	inset, gap, leftGap, assumedHeight: see alignButtons(),
+	spaceAbove: extra window height, so the row has more breathing space above it.
+	Returns the resulting row height, or None if the layout failed.
+	"""
+	buttons = tuple(leftButtons) + tuple(rightButtons)
+
+	def fallback():
+		# frame layout, as if the buttons had never been auto:
+		contentView = window._window.contentView()
+		try:
+			contentView.removeConstraints_(contentView.constraints())
+		except:
+			pass
+		for button in buttons:
+			button.getNSButton().setTranslatesAutoresizingMaskIntoConstraints_(True)
+		result = alignButtons(
+			window,
+			rightButtons=rightButtons,
+			leftButtons=leftButtons,
+			inset=inset,
+			gap=gap,
+			leftGap=leftGap,
+			assumedHeight=assumedHeight,
+			spaceAbove=spaceAbove,
+		)
+		return result[1] if result else None
+
+	if not supportsAutoLayout(window):
+		return fallback()
+
+	try:
+		# make the buttons keep their natural width, so that flexible gaps in the
+		# rules take up the slack, rather than the buttons stretching:
+		for button in buttons:
+			button.getNSButton().setContentHuggingPriority_forOrientation_(NSLayoutPriorityDefaultHigh, NSLayoutConstraintOrientationHorizontal)
+
+		window.addAutoPosSizeRules(rules, metrics)
+
+		# resolve the constraints, then measure what they amounted to:
+		contentView = window._window.contentView()
+		contentView.layoutSubtreeIfNeeded()
+		rowHeight = ceil(max(button.getNSButton().frame().size.height for button in buttons))
+
+		growWindow(window, deltaHeight=max(0, rowHeight - assumedHeight) + spaceAbove)
+		return rowHeight
+	except:
+		import traceback
+		print(traceback.format_exc())
+		print("⚠️ Could not lay out the button row with auto layout, falling back to frames.")
+		return fallback()
+
+
 def measureButtons(buttons, minButtonWidth=70, minHeight=20):
 	"""
 	Measures the sizes vanilla Buttons need on the running system.
@@ -379,18 +481,12 @@ def alignButtons(window, rightButtons=(), leftButtons=(), inset=15, gap=10, left
 		rowHeight = height + 2 * overhang
 
 		if resizeWindow:
-			windowWidth, windowHeight = window.getPosSize()[2], window.getPosSize()[3]
-			deltaWidth = max(0, rowWidth + 2 * inset - windowWidth)
-			deltaHeight = max(0, rowHeight - assumedHeight) + spaceAbove
-			if deltaWidth or deltaHeight:
-				nsWindow = window._window
-				for getter, setter in (
-					(nsWindow.contentMinSize, nsWindow.setContentMinSize_),
-					(nsWindow.contentMaxSize, nsWindow.setContentMaxSize_),
-				):
-					currentSize = getter()
-					setter(NSMakeSize(currentSize.width + deltaWidth, currentSize.height + deltaHeight))
-				window.resize(windowWidth + deltaWidth, windowHeight + deltaHeight, animate=False)
+			windowWidth = window.getPosSize()[2]
+			growWindow(
+				window,
+				deltaWidth=max(0, rowWidth + 2 * inset - windowWidth),
+				deltaHeight=max(0, rowHeight - assumedHeight) + spaceAbove,
+			)
 
 		# right group, positioned right to left:
 		rightEdge = sideInset


### PR DESCRIPTION
Pilot of the auto layout approach discussed after #487, on one script.

## Why

Auto layout positions views by their **alignment rects**, which is exactly the information frame layout lacks: macOS itself knows how far the button bezel is drawn beyond the frame, and how large a button needs to be. So the row needs no `tahoeDrawnButtonHeight`, no overhang estimate, no `minButtonWidth`, and nothing to re-tune when macOS 27 changes the metrics again.

Checked against vanilla's source (`vanillaBase.py`) rather than assuming:

- `_setAttr()` registers a view in `_autoLayoutViews` **only** if it was created with `posSize="auto"`, and VFL resolves `[name]` against that dict — so frame layout and auto layout genuinely mix in one superview, and only the buttons move to constraints.
- `setPosSize()` early-returns for auto views, so the `_recursiveSetFrame()` pass on window resize leaves them alone.
- `setPosSize(tuple)` on a view that *was* auto assigns `_posSize`, the autoresizing mask and the frame — which is what makes the fallback below possible.

## The row

```python
rules=(
    "H:|-border-[uncheckAllButton]-tight-[checkAllButton]",
    "H:[runButton]-border-|",
    "V:[uncheckAllButton]-border-|",
    "V:[checkAllButton]-border-|",
    "V:[runButton]-border-|",
),
metrics={"border": inset, "tight": 6},
```

Two independent horizontal rules — the pair pinned left, Build pinned right — rather than one chain with a flexible spacer. Nothing is over-constrained, and it uses only the plainest VFL tokens. The tradeoff: no enforced minimum gap between the two groups if the window ever gets much narrower. This window is fixed width, so that's fine for now; a flexible `Group("auto")` can be added later if a resizable window adopts this.

## Helpers

- `autoPosSize(window, framePosSize)` — returns `"auto"`, or the frame tuple if this vanilla predates auto layout.
- `layoutButtonRow(...)` — raises the buttons' content hugging so they keep their natural width, adds the rules, calls `layoutSubtreeIfNeeded()`, then grows the window by the **resolved** row height. Measured, not estimated.
- `growWindow()` — factored out of `alignButtons()`.

Failure handling: if the rules can't be applied, `layoutButtonRow()` removes the constraints, restores `translatesAutoresizingMaskIntoConstraints`, and lays the row out with the frame-based `alignButtons()`. Old vanilla and a runtime VFL failure both land in that same path, so a broken pilot degrades to the current behavior rather than to invisible buttons.

The frame-based helpers are untouched and still serve the other five converted scripts.

## Testing

Stubbed all three paths: auto layout available (rules stored, layout pass run, window grown from the resolved height, frames untouched), vanilla too old (frame fallback, positions as before), and VFL raising at runtime (constraints purged, autoresizing restored, frames applied). What the stub cannot tell us is whether the gaps *look* right on Tahoe — that's the point of the pilot.

If it looks correct, the remaining ~46 scripts get this pattern instead of the Tahoe constant, and `systemButtonMetrics()` eventually becomes dead code.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dKKjpeixqJgHZDjesF4g7)_