### PR TITLE
Make GSAnchor creation compatible with both Glyphs 3 and 4

### DIFF
--- a/Anchors/Add ZWRO origin Anchors.py
+++ b/Anchors/Add ZWRO origin Anchors.py
@@ -7,8 +7,8 @@ Insert *origin anchors for ZWRO in all combining marks of specified scripts.
 
 from AppKit import NSPoint, NSHeight
 import vanilla
-from GlyphsApp import Glyphs, GSAnchor, Message
-from mekkablue import mekkaObject, UpdateButton, reportFontName
+from GlyphsApp import Glyphs, Message
+from mekkablue import mekkaObject, newAnchorWithName, UpdateButton, reportFontName
 
 
 def moveMacroWindowSeparator(pos=20):
@@ -198,7 +198,7 @@ class AddZWROOriginAnchors(mekkaObject):
 										x = layer.bounds.origin.x
 								x += offset
 								anchorPosition = NSPoint(x, 0)
-								anchor = GSAnchor.alloc().initWithName_position_("*origin", anchorPosition)
+								anchor = newAnchorWithName("*origin", anchorPosition)
 								layer.anchors.append(anchor)
 								print(f"⚓️ {glyph.name}, {layer.name}: added {anchor.name} at {int(anchor.position.x)}x 0y")
 

--- a/Anchors/Add missing smart anchors.py
+++ b/Anchors/Add missing smart anchors.py
@@ -6,7 +6,8 @@ Adds all anchors for properties of selected smart glyphs on all their layers. Sk
 """
 
 from AppKit import NSPoint
-from GlyphsApp import Glyphs, GSAnchor
+from GlyphsApp import Glyphs
+from mekkablue import newAnchorWithName
 
 
 def process(glyph):
@@ -18,7 +19,7 @@ def process(glyph):
 			countOfLayers += 1
 			for i, axisName in enumerate(axisNames):
 				if not thisLayer.anchors[axisName]:
-					smartAnchor = GSAnchor.alloc().initWithName_position_(axisName, NSPoint(0, -i * 50))
+					smartAnchor = newAnchorWithName(axisName, NSPoint(0, -i * 50))
 					thisLayer.anchors.append(smartAnchor)
 					countOfAnchors += 1
 	print(f"  - added {countOfAnchors} anchors on {countOfLayers} smart layers.")

--- a/Anchors/Exit-Entry Manager.py
+++ b/Anchors/Exit-Entry Manager.py
@@ -8,7 +8,7 @@ add or remove the # prefix; swap or delete anchors — all from one place.
 """
 
 import vanilla
-from mekkablue import mekkaObject
+from mekkablue import mekkaObject, newAnchorWithName
 from Foundation import NSPoint
 from GlyphsApp import Glyphs, GSAnchor, GSPath, GSNode, GSOFFCURVE, GSLTR, GSRTL
 
@@ -256,10 +256,10 @@ class ExitEntryManager(mekkaObject):
 				glyphsProcessed += 1
 				for layer in self.getLayersFromGlyph(glyph):
 					if xEntry is not None and (not layer.anchors[entryName] or overwrite):
-						layer.anchors.append(GSAnchor.alloc().initWithName_position_(entryName, NSPoint(xEntry, 0.0)))
+						layer.anchors.append(newAnchorWithName(entryName, NSPoint(xEntry, 0.0)))
 						count += 1
 					if xExit is not None and (not layer.anchors[exitName] or overwrite):
-						layer.anchors.append(GSAnchor.alloc().initWithName_position_(exitName, NSPoint(xExit, 0.0)))
+						layer.anchors.append(newAnchorWithName(exitName, NSPoint(xExit, 0.0)))
 						count += 1
 		finally:
 			font.enableUpdateInterface()
@@ -300,23 +300,23 @@ class ExitEntryManager(mekkaObject):
 						if isInit or isMedi:
 							node = self.rightmostOncurve(layer)
 							if node and (not layer.anchors[exitName] or overwrite):
-								layer.anchors.append(GSAnchor.alloc().initWithName_position_(exitName, NSPoint(node.x, node.y)))
+								layer.anchors.append(newAnchorWithName(exitName, NSPoint(node.x, node.y)))
 								count += 1
 						if isMedi or isFina:
 							node = self.leftmostOncurve(layer)
 							if node and (not layer.anchors[entryName] or overwrite):
-								layer.anchors.append(GSAnchor.alloc().initWithName_position_(entryName, NSPoint(node.x, node.y)))
+								layer.anchors.append(newAnchorWithName(entryName, NSPoint(node.x, node.y)))
 								count += 1
 					else:
 						# RTL cursive (Arabic): exit connects to the left (x=0), entry from the right
 						if isInit or isMedi:
 							if not layer.anchors[exitName] or overwrite:
-								layer.anchors.append(GSAnchor.alloc().initWithName_position_(exitName, NSPoint(0.0, 0.0)))
+								layer.anchors.append(newAnchorWithName(exitName, NSPoint(0.0, 0.0)))
 								count += 1
 						if isMedi or isFina:
 							node = self.rightmostOncurve(layer)
 							if node and (not layer.anchors[entryName] or overwrite):
-								layer.anchors.append(GSAnchor.alloc().initWithName_position_(entryName, NSPoint(node.x, node.y)))
+								layer.anchors.append(newAnchorWithName(entryName, NSPoint(node.x, node.y)))
 								count += 1
 		finally:
 			font.enableUpdateInterface()

--- a/Anchors/Fix Arabic Anchor Order in Ligatures.py
+++ b/Anchors/Fix Arabic Anchor Order in Ligatures.py
@@ -6,7 +6,8 @@ Fix the order of top_X and bottom_X anchors to RTL.
 """
 
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSAnchor
+from GlyphsApp import Glyphs
+from mekkablue import newAnchorWithName
 
 
 Font = Glyphs.font
@@ -20,7 +21,7 @@ def makeAnchor(thisLayer, anchorName, x, y):
 	thisAnchorPosition.y = y
 	thisAnchorName = anchorName
 
-	thisAnchor = GSAnchor.alloc().initWithName_position_(thisAnchorName, thisAnchorPosition)
+	thisAnchor = newAnchorWithName(thisAnchorName, thisAnchorPosition)
 	thisLayer.addAnchor_(thisAnchor)
 
 	print("-- %s (%.1f, %.1f)" % (thisAnchorName, thisAnchorPosition.x, thisAnchorPosition.y))

--- a/Anchors/Steal Anchors.py
+++ b/Anchors/Steal Anchors.py
@@ -7,8 +7,8 @@ Batch-copy the anchors from one font master to another.
 
 import vanilla
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSAnchor, Message
-from mekkablue import mekkaObject, UpdateButton
+from GlyphsApp import Glyphs, Message
+from mekkablue import mekkaObject, newAnchorWithName, UpdateButton
 from mekkablue.geometry import italicize
 
 
@@ -219,7 +219,7 @@ class StealAnchors(mekkaObject):
 									targetLayer.anchors = None
 								for originAnchor in originLayer.anchors:
 									if not targetLayer.anchors[originAnchor.name]:
-										targetAnchor = GSAnchor.alloc().initWithName_position_(originAnchor.name, originAnchor.position)
+										targetAnchor = newAnchorWithName(originAnchor.name, originAnchor.position)
 										if self.pref("respectItalicAngle") and targetLayer.italicAngle != originLayer.italicAngle:
 											pivot = targetLayer.master.slantHeightForLayer_(targetLayer)
 											if not pivot:

--- a/Build Glyphs/Build Q from O and _tail.Q.py
+++ b/Build Glyphs/Build Q from O and _tail.Q.py
@@ -7,6 +7,7 @@ Run this script AFTER doing Component from Selection on the Q tail and naming it
 
 from copy import copy as copy
 from GlyphsApp import Glyphs, GSAnchor, GSComponent, Message
+from mekkablue import newAnchorWithName
 
 thisFont = Glyphs.font  # frontmost font
 Oglyph = thisFont.glyphs["O"]
@@ -27,7 +28,7 @@ else:
 		# if necessary, add anchors to _tail.Q
 		if not thisLayer.anchors[newAnchorName]:
 			defaultPosition = Oglyph.layers[masterID].anchors[anchorName].position
-			newAnchor = GSAnchor.alloc().initWithName_position_(newAnchorName, defaultPosition)
+			newAnchor = newAnchorWithName(newAnchorName, defaultPosition)
 			thisLayer.anchors.append(newAnchor)
 
 		# rebuild Q from O:

--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -7,8 +7,8 @@ Build and sync quotes: create single and double quotes with cursive attachment a
 
 import vanilla
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSAnchor, GSComponent, GSPath, GSNode, LINE, GSMetricsTypeCapHeight
-from mekkablue import alignButtons, mekkaObject, newGlyphWithName
+from GlyphsApp import Glyphs, GSComponent, GSPath, GSNode, LINE, GSMetricsTypeCapHeight
+from mekkablue import alignButtons, mekkaObject, newAnchorWithName, newGlyphWithName
 
 # Maps single quote → double quote
 SINGLE_TO_DOUBLE = {
@@ -346,8 +346,8 @@ class QuoteManager(mekkaObject):
 		toRemove = [a for a in layer.anchors if a.name in ("#entry", "#exit")]
 		for a in toRemove:
 			layer.anchors.remove(a)
-		layer.anchors.append(GSAnchor.alloc().initWithName_position_("#entry", NSPoint(0, 0)))
-		layer.anchors.append(GSAnchor.alloc().initWithName_position_("#exit", NSPoint(distance, 0)))
+		layer.anchors.append(newAnchorWithName("#entry", NSPoint(0, 0)))
+		layer.anchors.append(newAnchorWithName("#exit", NSPoint(distance, 0)))
 
 	# -----------------------------------------------------------------------
 	# Metrics keys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,7 @@ Negative coordinates are measured from the right/bottom edge (`-inset` = inset f
 | `reportTimeInNaturalLanguage(seconds)` | Formats a duration as a readable string (e.g., `"2:34 minutes"`) |
 | `newLineControlLayer()` | Returns a newline `GSControlLayer` for `tab.layers`; use instead of `GSControlLayer.newline()`, which raises a `TypeError` in some Glyphs versions |
 | `newGlyphWithName(glyphName)` | Returns a new `GSGlyph` with that name; use instead of `GSGlyph(glyphName)`, which raises a `TypeError` in some Glyphs versions |
+| `newAnchorWithName(anchorName, position=None)` | Returns a new `GSAnchor`; use instead of `GSAnchor(name, position)` (raises a `TypeError` in Glyphs 4) or `GSAnchor.alloc().initWithName_position_()` (missing in Glyphs 3) |
 | `getLegibleFont(size=None)` | Returns a system legible font (Glyphs 2/3 compatible) |
 | `UpdateButton(posSize, callback, title="")` | Creates a refresh button with an NSRefreshTemplate icon |
 

--- a/Paths/Rotate around anchor.py
+++ b/Paths/Rotate around anchor.py
@@ -7,8 +7,8 @@ Rotate selected glyphs (or selected paths and components) around a 'rotate' anch
 
 import vanilla
 from Foundation import NSPoint, NSAffineTransform
-from GlyphsApp import Glyphs, GSAnchor
-from mekkablue import mekkaObject, UpdateButton
+from GlyphsApp import Glyphs
+from mekkablue import mekkaObject, newAnchorWithName, UpdateButton
 from mekkablue.geometry import centerOfRect
 
 rotateAnchorName = "rotate"
@@ -69,7 +69,7 @@ class Rotator(mekkaObject):
 			myRotationCenter = NSPoint()
 			myRotationCenter.x = int(self.pref("anchor_x"))
 			myRotationCenter.y = int(self.pref("anchor_y"))
-			myRotationAnchor = GSAnchor.alloc().initWithName_position_("#%s" % rotateAnchorName, myRotationCenter)
+			myRotationAnchor = newAnchorWithName("#%s" % rotateAnchorName, myRotationCenter)
 			for thisLayer in selectedLayers:
 				# adds '#rotate' if it doesn't exist, resets it if it exists:
 				thisLayer.addAnchor_(myRotationAnchor)

--- a/__init__.py
+++ b/__init__.py
@@ -2,8 +2,8 @@
 from math import ceil
 from typing import Any
 from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSLayoutConstraintOrientationHorizontal, NSLayoutPriorityDefaultHigh, NSMakeSize, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
-from Foundation import NSProcessInfo
-from GlyphsApp import Glyphs, GSFeature, GSClass, GSControlLayer, GSGlyph
+from Foundation import NSProcessInfo, NSPoint
+from GlyphsApp import Glyphs, GSAnchor, GSFeature, GSClass, GSControlLayer, GSGlyph
 from vanilla import Button
 
 if Glyphs.versionNumber >= 3:
@@ -263,6 +263,22 @@ def newGlyphWithName(glyphName):
 		glyph = GSGlyph()
 		glyph.name = glyphName
 		return glyph
+
+
+def newAnchorWithName(anchorName, position=None):
+	"""
+	Returns a new GSAnchor carrying the supplied name and position.
+	Temporary workaround: in Glyphs 4, GSAnchor("name", position) raises
+	'TypeError: GSAnchor() does not accept positional arguments', so we use the
+	ObjC initializer there. In Glyphs 3 and earlier, that ObjC initializer does
+	not exist ('GSAnchor' object has no attribute 'initWithName_position_'), so
+	we keep the positional arguments.
+	"""
+	if position is None:
+		position = NSPoint(0, 0)
+	if Glyphs.versionNumber >= 4:
+		return GSAnchor.alloc().initWithName_position_(anchorName, position)
+	return GSAnchor(anchorName, position)
 
 
 def getLegibleFont(size=None):


### PR DESCRIPTION
## Problem

Commit 5ec06ad replaced `GSAnchor(name, position)` with `GSAnchor.alloc().initWithName_position_(name, position)` to work around Glyphs 4 rejecting positional arguments. That initializer does not exist in Glyphs 3, so the affected scripts now fail there:

```
Quote Manager Error: 'GSAnchor' object has no attribute 'initWithName_position_'
  File "Quote Manager.py", line 349, in setAnchors
    layer.anchors.append(GSAnchor.alloc().initWithName_position_("#entry", NSPoint(0, 0)))
AttributeError: 'GSAnchor' object has no attribute 'initWithName_position_'
```

## Changes

- `__init__.py`: new shared helper `newAnchorWithName(anchorName, position=None)` that branches on `Glyphs.versionNumber` — the ObjC initializer for Glyphs 4 and up, positional arguments for Glyphs 3 and earlier. Placed next to the existing `newGlyphWithName()` / `newLineControlLayer()` workarounds.
- All 14 call sites introduced by 5ec06ad now go through the helper, across 8 scripts:
  - `Anchors/Add ZWRO origin Anchors.py`
  - `Anchors/Add missing smart anchors.py`
  - `Anchors/Exit-Entry Manager.py`
  - `Anchors/Fix Arabic Anchor Order in Ligatures.py`
  - `Anchors/Steal Anchors.py`
  - `Build Glyphs/Build Q from O and _tail.Q.py`
  - `Build Glyphs/Quote Manager.py`
  - `Paths/Rotate around anchor.py`
- Imports adjusted: `newAnchorWithName` imported from `mekkablue`, `GSAnchor` dropped from `GlyphsApp` imports where it is no longer referenced (it stays where bare `GSAnchor()` is still used).
- `CLAUDE.md`: helper documented in the shared-utilities table.

Bare `GSAnchor()` calls with no arguments were already version-safe and are left untouched.

## Verification

All touched files compile (`py_compile`), and `flake8` reports the same 25 pre-existing findings as on `master` — no new ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1e8GzNxNqd4qufSyHTjRn)_