### PR TITLE
Fix stem writing for Glyphs 4

### DIFF
--- a/Font Info/Turn Dimensions into Stems.py
+++ b/Font Info/Turn Dimensions into Stems.py
@@ -1,11 +1,11 @@
-#MenuTitle: Turn Dimensions into Stems
+# MenuTitle: Turn Dimensions into Stems
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
-__doc__="""
+__doc__ = """
 Turns all H and V dimensions (in the Dimensions palette) into H and V stems.
 """
 
-from GlyphsApp import GSMetric, GSInfoValue
+from GlyphsApp import Glyphs, GSMetric
 
 font = Glyphs.font
 dimensions = font.userData["GSDimensionPlugin.Dimensions"]
@@ -24,7 +24,6 @@ for masterID in dimensions.keys():
 		else:
 			stem = font.stems[dimKey]
 		value = dimensions[masterID][dimKey]
-		info = GSInfoValue.alloc().initWithValue_(int(value) or 0)
-		master.setStemValue_forId_(info, stem.id)
+		master.stems[stem.id] = int(value) or 0
 
 font.parent.windowController().showFontInfoWindowWithTabSelected_(1)

--- a/Hinting/Auto Stems.py
+++ b/Hinting/Auto Stems.py
@@ -7,7 +7,7 @@ Derive one H and one V stem value for all your masters by measuring certain shap
 
 import vanilla
 from Foundation import NSPoint
-from GlyphsApp import Glyphs, GSMetric, GSInfoValue, Message
+from GlyphsApp import Glyphs, GSMetric, Message
 from mekkablue import mekkaObject, UpdateButton, reportFontName
 
 whichMeasure = (
@@ -47,6 +47,7 @@ class AutoStems(mekkaObject):
 
 		# UI elements:
 		linePos, inset, lineHeight = 12, 15, 22
+		glyphNames = self.glyphNames()
 		self.w.descriptionText = vanilla.TextBox((inset, linePos, -inset, 14), "Measure shapes in the font and derive stem entries", sizeStyle="small", selectable=True)
 		linePos += lineHeight
 
@@ -57,7 +58,7 @@ class AutoStems(mekkaObject):
 		self.w.vShape = vanilla.PopUpButton((inset + 150, linePos, 110, 17), whichShape, sizeStyle="small", callback=self.SavePreferences)
 		self.w.vShape.setToolTip("Which shape in the glyph to measure for the vertical stem.")
 		self.w.vText3 = vanilla.TextBox((inset + 263, linePos + 2, 17, 14), "of", sizeStyle="small", selectable=True)
-		self.w.vStemGlyph = vanilla.ComboBox((inset + 280, linePos - 1, -inset - 25, 19), [g.name for g in Glyphs.font.glyphs], sizeStyle="small", callback=self.SavePreferences)
+		self.w.vStemGlyph = vanilla.ComboBox((inset + 280, linePos - 1, -inset - 25, 19), glyphNames, sizeStyle="small", callback=self.SavePreferences)
 		self.w.vStemGlyph.setToolTip("Pick a glyph to measure for the vertical stem.")
 		self.w.vReset = UpdateButton((-inset - 18, linePos - 1, -inset, 18), callback=self.update)
 		resetToolTip = "Reload the glyph list of the frontmost font."
@@ -71,7 +72,7 @@ class AutoStems(mekkaObject):
 		self.w.hShape = vanilla.PopUpButton((inset + 150, linePos, 110, 17), whichShape, sizeStyle="small", callback=self.SavePreferences)
 		self.w.hShape.setToolTip("Which shape in the glyph to measure for the horizontal stem.")
 		self.w.hText3 = vanilla.TextBox((inset + 263, linePos + 2, 17, 14), "of", sizeStyle="small", selectable=True)
-		self.w.hStemGlyph = vanilla.ComboBox((inset + 280, linePos - 1, -inset - 25, 19), [g.name for g in Glyphs.font.glyphs], sizeStyle="small", callback=self.SavePreferences)
+		self.w.hStemGlyph = vanilla.ComboBox((inset + 280, linePos - 1, -inset - 25, 19), glyphNames, sizeStyle="small", callback=self.SavePreferences)
 		self.w.hStemGlyph.setToolTip("Pick a glyph to measure for the horizontal stem.")
 		self.w.hReset = UpdateButton((-inset - 18, linePos - 1, -inset, 18), callback=self.update)
 		self.w.hReset.setToolTip(resetToolTip)
@@ -96,11 +97,18 @@ class AutoStems(mekkaObject):
 		self.w.open()
 		self.w.makeKey()
 
+	def glyphNames(self):
+		font = Glyphs.font
+		if not font:
+			return []
+		return [g.name for g in font.glyphs]
+
 	def update(self, sender=None):
+		glyphNames = self.glyphNames()
 		if sender == self.w.hReset:
-			self.w.hStemGlyph.setItems([g.name for g in Glyphs.font.glyphs])
+			self.w.hStemGlyph.setItems(glyphNames)
 		if sender == self.w.vReset:
-			self.w.vStemGlyph.setItems([g.name for g in Glyphs.font.glyphs])
+			self.w.vStemGlyph.setItems(glyphNames)
 
 	def measureLayer(self, layer, measure, shape, v=True):
 		layerCopy = layer.copyDecomposedLayer()
@@ -204,10 +212,8 @@ class AutoStems(mekkaObject):
 
 					# set stems:
 					print(f"V {vStem} H {hStem}: {m.name}")
-					vInfo = GSInfoValue.alloc().initWithValue_(vStem)
-					hInfo = GSInfoValue.alloc().initWithValue_(hStem)
-					m.setStemValue_forId_(vInfo, vID)
-					m.setStemValue_forId_(hInfo, hID)
+					m.stems[vID] = vStem
+					m.stems[hID] = hStem
 
 				print()
 


### PR DESCRIPTION
## The bug

Auto Stems fails in Glyphs 4 right after measuring the first master:

```
V 19.0 H 17.0: Thin
Auto Stems Error: 'GSInfoValue' object has no attribute 'initWithValue_'
Traceback (most recent call last):
  File "Auto Stems.py", line 207, in AutoStemsMain
    vInfo = GSInfoValue.alloc().initWithValue_(vStem)
AttributeError: 'GSInfoValue' object has no attribute 'initWithValue_'
```

`GSInfoValue` still exists in Glyphs 4, but only for the font info properties (`GSInfoValueSingle` / `GSInfoValueLocalized` in `font.properties`, `master.properties`, `instance.properties`). It is no longer the carrier for stem values, and it has no `initWithValue_` initializer any more.

## The fix

Stem values are plain numbers again, and the documented `GSFontMaster.stems` proxy is the supported way to write them:

```python
stem = GSMetric()
stem.horizontal = False  # or True
stem.name = "Some Name"
font.stems.append(stem)
master.stems[stem.name] = 123
```

Both wrapper generations implement that proxy on top of `setStemValueValue_forId_()`, and both accept the stem **id** as the key — Glyphs 3 falls back from `stemForName_()` to `stemForId_()`, Glyphs 4 passes the key straight through as the id. So the two lines work unchanged in Glyphs 3 and Glyphs 4:

```python
m.stems[vID] = vStem
m.stems[hID] = hStem
```

Using the id rather than the name also keeps the two stems apart if the font already carries stems called `V` and `H`.

The rest of `Auto Stems.py` was checked against the current reference — `GSMetric.name` / `.id` / `.type` / `.horizontal`, `font.stems.append()`, `GSFont.parent`, `GSLayer.parent`, `copyDecomposedLayer()`, `intersectionsBetweenPoints()`, `layer.shapes` deletion and `layer.bounds` are all unchanged in Glyphs 4.

## Also in this PR

- **`Font Info/Turn Dimensions into Stems.py`** had the identical `GSInfoValue.alloc().initWithValue_()` call and broke the same way; it now uses `master.stems[stem.id] = …` too. That script also never imported `Glyphs`, and its header did not follow the house format (`#MenuTitle:`, `__doc__=`), so both are fixed.
- **No-font crash in Auto Stems.** The window filled both glyph combo boxes from `Glyphs.font.glyphs` while it was being built, so with no font open the script raised before the window appeared — even though `AutoStemsMain()` has a “No Font Open” message for exactly that case. The names now come from a small `glyphNames()` helper that returns an empty list when there is no font, and `update()` reuses it.

## Testing

Glyphs.app is not available in this environment, so the scripts were not executed. Verified by reading the Glyphs 3 and Glyphs 4 Python wrappers (`MasterStemsProxy`, `FontStemsProxy`, `GSMetric`, `GSFontMaster.stems`) to confirm the replacement call exists and behaves identically on both, plus `py_compile` and a clean `ruff check` on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NLLHXZfuFU2gtvhpzp4U7

---
_Generated by [Claude Code](https://claude.ai/code/session_017NLLHXZfuFU2gtvhpzp4U7)_