### PR TITLE
Fix guides access for Glyphs 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,8 @@ Read it, but prefer Auto Layout for new windows and when reworking an existing o
 | `reportTimeInNaturalLanguage(seconds)` | Formats a duration as a readable string (e.g., `"2:34 minutes"`) |
 | `newLineControlLayer()` | Returns a newline `GSControlLayer` for `tab.layers`; use instead of `GSControlLayer.newline()`, which raises a `TypeError` in some Glyphs versions |
 | `newGlyphWithName(glyphName)` | Returns a new `GSGlyph` with that name; use instead of `GSGlyph(glyphName)`, which raises a `TypeError` in some Glyphs versions |
+| `guidesOf(layerOrMaster)` | Returns the guides of a `GSLayer` or `GSFontMaster`; use instead of `.guideLines`, which is gone in Glyphs 4, or `.guides`, which does not exist in Glyphs 2 |
+| `clearGuides(layerOrMaster)` | Deletes all guides of a `GSLayer` or `GSFontMaster`, Glyphs 2/3/4 compatible |
 | `newAnchorWithName(anchorName, position=None)` | Returns a new `GSAnchor`; use instead of `GSAnchor(name, position)` (raises a `TypeError` in Glyphs 4) or `GSAnchor.alloc().initWithName_position_()` (missing in Glyphs 3) |
 | `getLegibleFont(size=None)` | Returns a system legible font (Glyphs 2/3 compatible) |
 | `UpdateButton(posSize, callback, title="")` | Creates a refresh button with an NSRefreshTemplate icon; `posSize` may be `"auto"` |

--- a/Glyph Names, Notes and Unicode/Garbage Collection.py
+++ b/Glyph Names, Notes and Unicode/Garbage Collection.py
@@ -7,7 +7,7 @@ Removes annotations, glyph notes, guides, and node names.
 
 import vanilla
 from GlyphsApp import Glyphs
-from mekkablue import mekkaObject, UpdateButton
+from mekkablue import mekkaObject, UpdateButton, clearGuides, guidesOf
 
 
 def extractUserDataKeys(obj):
@@ -310,11 +310,11 @@ class GarbageCollection(mekkaObject):
 											thisNode.name = None
 
 							if removeLocalGuides:
-								localGuidesGlyph += len(thisLayer.guideLines)
-								thisLayer.guideLines = None
+								localGuidesGlyph += len(guidesOf(thisLayer))
+								clearGuides(thisLayer)
 
-								localGuidesGlyph += len(thisLayer.background.guideLines)
-								thisLayer.background.guideLines = None
+								localGuidesGlyph += len(guidesOf(thisLayer.background))
+								clearGuides(thisLayer.background)
 
 							if removeAnnotations:
 								removeAnnotationsGlyph += len(thisLayer.annotations)
@@ -383,7 +383,7 @@ class GarbageCollection(mekkaObject):
 					self.log("📏 Removing global guides ...")
 					for thisMaster in thisFont.masters:
 						if thisMaster == thisFont.selectedFontMaster or not currentMasterOnly:
-							thisMaster.guideLines = None
+							clearGuides(thisMaster)
 
 				# Remove User Data (font level):
 				if self.pref("userDataFont"):

--- a/Guides/Remove Global Guides in Current Master.py
+++ b/Guides/Remove Global Guides in Current Master.py
@@ -4,11 +4,12 @@ from __future__ import division, print_function, unicode_literals
 __doc__ = """
 Deletes all global guidelines in the current master.
 """
+from mekkablue import clearGuides, guidesOf
 from GlyphsApp import Glyphs
 
 thisFont = Glyphs.font  # frontmost font
 thisFontMaster = thisFont.selectedFontMaster  # active master
-numberOfGuidelines = len(thisFontMaster.guideLines)
-thisFontMaster.guideLines = []
+numberOfGuidelines = len(guidesOf(thisFontMaster))
+clearGuides(thisFontMaster)
 
 print("Deleted %i global guides in Font %s, Master %s." % (numberOfGuidelines, thisFont.familyName, thisFontMaster.name))

--- a/Guides/Remove Local Guides in Selected Glyphs.py
+++ b/Guides/Remove Local Guides in Selected Glyphs.py
@@ -5,6 +5,7 @@ __doc__ = """
 Delete all local (blue) guides in selected glyphs.
 """
 
+from mekkablue import clearGuides
 from GlyphsApp import Glyphs
 
 print("Deleting guides in:")
@@ -12,6 +13,6 @@ print("Deleting guides in:")
 for thisLayer in Glyphs.font.selectedLayers:
 	thisGlyph = thisLayer.parent
 	# thisGlyph.beginUndo()  # undo grouping causes crashes
-	thisLayer.guideLines = None
+	clearGuides(thisLayer)
 	# thisGlyph.endUndo()  # undo grouping causes crashes
 	print("  %s" % thisGlyph.name)

--- a/__init__.py
+++ b/__init__.py
@@ -280,6 +280,29 @@ def newAnchorWithName(anchorName, position=None):
 	return GSAnchor(anchorName, position)
 
 
+def guidesOf(layerOrMaster):
+	"""
+	Returns the guides of a GSLayer or a GSFontMaster.
+	Temporary workaround: Glyphs 4 has dropped the deprecated guideLines property
+	('GSLayer' object has no attribute 'guideLines'), while Glyphs 2 does not know
+	the guides property yet, so we use whichever the object actually has.
+	"""
+	if hasattr(layerOrMaster, "guideLines"):
+		return layerOrMaster.guideLines
+	return layerOrMaster.guides
+
+
+def clearGuides(layerOrMaster):
+	"""
+	Deletes all guides of a GSLayer or a GSFontMaster.
+	See guidesOf() for why we need to distinguish between guideLines and guides.
+	"""
+	if hasattr(layerOrMaster, "guideLines"):
+		layerOrMaster.guideLines = None
+	else:
+		layerOrMaster.guides = []
+
+
 def getLegibleFont(size=None):
 	if size is None:
 		size = NSFont.systemFontSize()


### PR DESCRIPTION
## Problem

Garbage Collection crashes in Glyphs 4 as soon as *Remove local guides* is switched on:

```
😫 Garbage Collection Error: 'GSLayer' object has no attribute 'guideLines'
  File "Garbage Collection.py", line 313, in GarbageCollectionMain
    localGuidesGlyph += len(thisLayer.guideLines)
AttributeError: 'GSLayer' object has no attribute 'guideLines'
```

Glyphs 4 has dropped the deprecated `guideLines` property on `GSLayer` and `GSFontMaster`. Simply switching to `guides` is not enough, because Glyphs 2 does not know `guides` yet — so neither name works across all supported versions.

## Fix

Two small helpers in `__init__.py` that pick whichever property the object actually has:

- `guidesOf(layerOrMaster)` — returns the guides of a `GSLayer` or `GSFontMaster`
- `clearGuides(layerOrMaster)` — deletes all of them

The dispatch is by `hasattr(layerOrMaster, "guideLines")`, not by `Glyphs.versionNumber`, so on Glyphs 2 and 3 the exact same code as before runs and behavior there is unchanged; only Glyphs 4 takes the new `guides` path.

## Scripts updated

Every place that touched `guideLines` directly, all of which fail the same way in Glyphs 4:

- `Glyph Names, Notes and Unicode/Garbage Collection.py` (local guides, layer backgrounds, global guides)
- `Guides/Remove Local Guides in Selected Glyphs.py`
- `Guides/Remove Global Guides in Current Master.py`

`CLAUDE.md` documents the two new helpers in the shared-utilities table.

## Testing

`flake8` on the touched files reports nothing new (the one `E303` in `__init__.py:104` is pre-existing on `master`), and all four files compile. The runtime behavior itself needs Glyphs.app and was not executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPjR4DHVdtntkrsk9v5rjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPjR4DHVdtntkrsk9v5rjC)_