### PR TITLE
Quote Manager alignment/anchor fixes, and layerGroups() for compatibility runs

### DIFF
--- a/Build Glyphs/Quote Manager.py
+++ b/Build Glyphs/Quote Manager.py
@@ -144,7 +144,8 @@ class QuoteManager(mekkaObject):
 		)
 		self.w.updateButton = vanilla.Button("auto", "Update", callback=self.update)
 		self.w.updateButton.setToolTip(
-			"Update metrics keys, anchors, and kern groups for all selected quote groups. Does not overwrite existing paths."
+			"Update metrics keys, kern groups and component alignment for all selected quote groups, "
+			"and reset the #entry/#exit anchors based on the default single quote. Does not overwrite existing paths."
 		)
 		self.w.buildButton = vanilla.Button("auto", "Build", callback=self.build)
 		self.w.buildButton.setToolTip(
@@ -304,6 +305,50 @@ class QuoteManager(mekkaObject):
 		layer.anchors.append(newAnchorWithName("#entry", NSPoint(0, 0)))
 		layer.anchors.append(newAnchorWithName("#exit", NSPoint(distance, 0)))
 
+	def ensureDefaultAnchors(self, font, defaultName):
+		"""Make sure the default glyph carries #entry/#exit in every master, so it can serve as anchor reference."""
+		g = font.glyphs[defaultName] if defaultName else None
+		if not g:
+			return
+		for master in font.masters:
+			layer = g.layers[master.id]
+			if not layer.anchors["#entry"] or not layer.anchors["#exit"]:
+				self.setAnchors(layer)
+				print(f"\t⚓ Added anchors to {defaultName} / {master.name}")
+
+	# -----------------------------------------------------------------------
+	# Component alignment
+	# -----------------------------------------------------------------------
+
+	def componentIsFlipped(self, component):
+		"""True if the component transform mirrors the component, i.e. the matrix has a negative determinant."""
+		try:
+			transformValues = tuple(component.transform)
+		except Exception:
+			transformValues = None
+		if transformValues and len(transformValues) >= 4:
+			xx, xy, yx, yy = transformValues[:4]
+			return (xx * yy - xy * yx) < 0
+		scale = getattr(component, "scale", None)
+		if scale:
+			return (scale[0] * scale[1]) < 0
+		return False
+
+	def setComponentAlignment(self, component):
+		"""Auto-align the component, except when it is mirrored: flipped components are always left unaligned.
+
+		Returns True if automatic alignment was switched on, False if it was disabled.
+		"""
+		if self.componentIsFlipped(component):
+			currentPosition = component.position
+			component.automaticAlignment = False
+			component.disableAlignment = True
+			if currentPosition is not None:
+				component.position = currentPosition
+			return False
+		component.automaticAlignment = True
+		return True
+
 	# -----------------------------------------------------------------------
 	# Metrics keys
 	# -----------------------------------------------------------------------
@@ -409,7 +454,7 @@ class QuoteManager(mekkaObject):
 	# -----------------------------------------------------------------------
 
 	def syncAnchorsFromDefault(self, font, singles, defaultQuote, defaultGuillemet):
-		"""Copy #entry/#exit positions from the relevant default to each single."""
+		"""Reset #entry/#exit of every single to the positions of the relevant default. Existing anchors are always replaced."""
 		for singleName in singles:
 			isGuillemet = singleName in ("guilsinglleft", "guilsinglright")
 			defaultName = defaultGuillemet if isGuillemet else defaultQuote
@@ -643,11 +688,11 @@ class QuoteManager(mekkaObject):
 				layer.clear()
 
 				comp = GSComponent(sourceName)
-				comp.automaticAlignment = True
 				try:
 					layer.shapes.append(comp)
 				except Exception:
 					layer.components.append(comp)
+				self.setComponentAlignment(comp)
 
 				print(f"\t🔤 {apostropheName} ← composite of {sourceName} / {master.name}")
 
@@ -673,13 +718,14 @@ class QuoteManager(mekkaObject):
 			layer.clear()
 
 			comp = GSComponent(defaultGuillemet)
-			comp.automaticAlignment = True
-			# Horizontal mirror (-100% scale on x); auto-alignment manages the translation
+			# Horizontal mirror (-100% scale on x); the translation moves it back into the advance
 			comp.transform = (-1, 0, 0, 1, defaultLayer.width, 0)
 			try:
 				layer.shapes.append(comp)
 			except Exception:
 				layer.components.append(comp)
+			# mirrored components are never auto-aligned
+			self.setComponentAlignment(comp)
 
 			layer.width = defaultLayer.width
 			print(f"\t🔤 {otherGuillemet} ← mirrored composite of {defaultGuillemet} / {master.name}")
@@ -714,23 +760,24 @@ class QuoteManager(mekkaObject):
 
 				for _ in range(2):
 					comp = GSComponent(singleName)
-					comp.automaticAlignment = True
 					try:
 						ggl.shapes.append(comp)
 					except Exception:
 						ggl.components.append(comp)
+					self.setComponentAlignment(comp)
 
 				print(f"\t🔤 {doubleName} ← 2× {singleName} / {master.name}")
 
-	def ensureAutoAlignedComponents(self, font, glyphNames):
-		"""Set automaticAlignment=True on every component in the given glyphs (double quotes, apostrophes)."""
+	def syncComponentAlignment(self, font, glyphNames):
+		"""Auto-align every component in the given glyphs (double quotes, apostrophes), except mirrored ones, which always get alignment disabled."""
 		for name in glyphNames:
 			g = font.glyphs[name]
 			if not g:
 				continue
 			for layer in g.layers:
 				for c in layer.components:
-					c.automaticAlignment = True
+					if not self.setComponentAlignment(c):
+						print(f"\t🚫 Alignment disabled for mirrored {c.componentName} in {name} / {layer.name}")
 
 	# -----------------------------------------------------------------------
 	# Validate default quote
@@ -770,13 +817,9 @@ class QuoteManager(mekkaObject):
 			glyphsToOpen = []
 
 			for defaultName in filter(None, [self.getDefaultQuoteName(), self.getDefaultGuillemetsName()]):
-				g = self.ensureGlyphExists(font, defaultName)
+				self.ensureGlyphExists(font, defaultName)
 				glyphsToOpen.append(defaultName)
-				for master in font.masters:
-					layer = g.layers[master.id]
-					if not layer.anchors["#entry"] or not layer.anchors["#exit"]:
-						self.setAnchors(layer)
-						print(f"\t⚓ Added anchors to {defaultName} / {master.name}")
+				self.ensureDefaultAnchors(font, defaultName)
 
 			if self.prefBool("doDumbQuotes"):
 				self.ensureGlyphExists(font, "quotesingle")
@@ -812,7 +855,12 @@ class QuoteManager(mekkaObject):
 
 			self.resetMetricsKeys(font, groups)
 			self.setMetricsKeys(font, groups, defaultQuote, defaultGuillemet)
+
+			# always reset #entry/#exit based on the default single quote (and the default guillemet)
+			self.ensureDefaultAnchors(font, defaultQuote)
+			self.ensureDefaultAnchors(font, defaultGuillemet)
 			self.syncAnchorsFromDefault(font, singles, defaultQuote, defaultGuillemet)
+
 			self.setKernGroups(font, singles)
 
 			mirrorGuillemet = (
@@ -825,7 +873,7 @@ class QuoteManager(mekkaObject):
 				+ (list(APOSTROPHE_COMPOSITES.keys()) if "apostrophes" in groups else [])
 				+ mirrorGuillemet
 			)
-			self.ensureAutoAlignedComponents(font, compositeGlyphs)
+			self.syncComponentAlignment(font, compositeGlyphs)
 
 			for name in self.getAllAffectedNames(groups):
 				g = font.glyphs[name]
@@ -911,16 +959,10 @@ class QuoteManager(mekkaObject):
 
 			# 7. Sync anchors from default
 			print("\nSyncing anchors:")
+			# Set the anchors on the defaults first, then reset all singles based on them
+			self.ensureDefaultAnchors(font, defaultQuote)
+			self.ensureDefaultAnchors(font, defaultGuillemet)
 			self.syncAnchorsFromDefault(font, singles, defaultQuote, defaultGuillemet)
-			# Also set anchors on the default itself if missing
-			if defaultQuote:
-				g = font.glyphs[defaultQuote]
-				if g:
-					for master in font.masters:
-						layer = g.layers[master.id]
-						if not layer.anchors["#entry"] or not layer.anchors["#exit"]:
-							self.setAnchors(layer)
-							print(f"\t⚓ Added anchors to {defaultQuote} / {master.name}")
 
 			# 8. Build double quotes (always overwrite if single is not empty)
 			print("\nBuilding double quotes:")
@@ -941,7 +983,7 @@ class QuoteManager(mekkaObject):
 				+ (list(APOSTROPHE_COMPOSITES.keys()) if "apostrophes" in groups else [])
 				+ mirrorGuillemet
 			)
-			self.ensureAutoAlignedComponents(font, compositeGlyphs)
+			self.syncComponentAlignment(font, compositeGlyphs)
 
 			# 11. Refresh metrics
 			for name in self.getAllAffectedNames(groups):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,7 @@ Read it, but prefer Auto Layout for new windows and when reworking an existing o
 | `newGlyphWithName(glyphName)` | Returns a new `GSGlyph` with that name; use instead of `GSGlyph(glyphName)`, which raises a `TypeError` in some Glyphs versions |
 | `guidesOf(layerOrMaster)` | Returns the guides of a `GSLayer` or `GSFontMaster`; use instead of `.guideLines`, which is gone in Glyphs 4, or `.guides`, which does not exist in Glyphs 2 |
 | `clearGuides(layerOrMaster)` | Deletes all guides of a `GSLayer` or `GSFontMaster`, Glyphs 2/3/4 compatible |
+| `layerGroupsOf(glyph)` | Returns the interpolation-compatible layer ID groups of a `GSGlyph` as tuples; use instead of `layerGroups_masters_error_()`, which groups by instances — not the default in Glyphs 3/4 — and instead of `glyph.layerGroups()`, which does not exist in Glyphs 3.1 |
 | `newAnchorWithName(anchorName, position=None)` | Returns a new `GSAnchor`; use instead of `GSAnchor(name, position)` (raises a `TypeError` in Glyphs 4) or `GSAnchor.alloc().initWithName_position_()` (missing in Glyphs 3) |
 | `getLegibleFont(size=None)` | Returns a system legible font (Glyphs 2/3 compatible) |
 | `UpdateButton(posSize, callback, title="")` | Creates a refresh button with an NSRefreshTemplate icon; `posSize` may be `"auto"` |

--- a/Components/Sync Components Across Masters.py
+++ b/Components/Sync Components Across Masters.py
@@ -4,17 +4,9 @@ from __future__ import division, print_function, unicode_literals
 __doc__ = """
 Takes the current layer’s components, and resets all other masters to the same component structure. Ignores paths and anchors. Hold down Option key to delete all paths and anchors.
 """
-from AppKit import NSEvent, NSAlternateKeyMask
+from mekkablue import layerGroupsOf
 from GlyphsApp import Glyphs, GSComponent
-
-# needed for 3.1
-from AppKit import NSMutableSet
-from GlyphsApp import GSGlyph, python_method
-if not hasattr(GSGlyph, 'layerGroups'):
-	def __GSGlyph_layerGroups__(self):
-		seenLayers = NSMutableSet.set()
-		return self.forcedLayerGroupIdsSeenLayers_(seenLayers)
-	GSGlyph.layerGroups = python_method(__GSGlyph_layerGroups__)
+from AppKit import NSEvent, NSAlternateKeyMask
 
 Glyphs.clearLog()
 thisFont = Glyphs.font  # frontmost font
@@ -39,8 +31,7 @@ def process(thisLayer):
 		return
 
 	compatibilityRun = None
-	for layerGroup in thisGlyph.layerGroups():
-		layerGroup = tuple(layerGroup)
+	for layerGroup in layerGroupsOf(thisGlyph):
 		if layerID in layerGroup:
 			compatibilityRun = layerGroup
 			break

--- a/Interpolation/Dekink Masters.py
+++ b/Interpolation/Dekink Masters.py
@@ -5,8 +5,9 @@ __doc__ = """
 Synchronize node distance proportions for angled smooth connections through all masters (and other compatible layers), thus avoiding interpolation kinks. Select one or more nodes in triplets and run the script. The selected nodes will be moved in all other masters.
 """
 
-from Foundation import NSPoint, NSArray, NSSize
+from mekkablue import layerGroupsOf
 from GlyphsApp import Glyphs, GSNode, GSSMOOTH, Message
+from Foundation import NSPoint, NSSize
 
 
 def vectorFromNodes(n1, n2):
@@ -46,14 +47,10 @@ currentGlyph = currentLayer.parent
 
 # find compatible layers in the same glyph:
 layerIDs = []
-instances = [i for i in currentFont.instances if i.type == 0]
-for subrunArray in currentGlyph.layerGroups_masters_error_(NSArray(instances), NSArray(currentFont.masters), None):
-	if subrunArray:
-		subrun = tuple(subrunArray[0])
-		if currentLayer.layerId in subrun:
-			for ID in subrun:
-				if ID != currentLayer.layerId:
-					layerIDs.append(ID)
+for layerGroup in layerGroupsOf(currentGlyph):
+	if currentLayer.layerId in layerGroup:
+		layerIDs.extend(ID for ID in layerGroup if ID != currentLayer.layerId)
+		break
 
 # if there are any compatible layers...
 if not layerIDs:

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 
 from typing import Any
-from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
+from AppKit import NSUserDefaults, NSFont, NSImage, NSImageLeading, NSMutableSet, NSPasteboard, NSStringPboardType, NSLineBreakByClipping
 from Foundation import NSPoint
 from GlyphsApp import Glyphs, GSAnchor, GSFeature, GSClass, GSControlLayer, GSGlyph
 from vanilla import Button
@@ -301,6 +301,25 @@ def clearGuides(layerOrMaster):
 		layerOrMaster.guideLines = None
 	else:
 		layerOrMaster.guides = []
+
+
+def layerGroupsOf(glyph):
+	"""
+	Returns the groups of interpolation-compatible layer IDs of a GSGlyph,
+	each group as a tuple of layer IDs.
+	Prefer this over determining the compatibility runs from the instances with
+	layerGroups_masters_error_(): in Glyphs 3 and 4, the layers are not grouped
+	by instance anymore, and glyph.layerGroups() takes the relevant parameters
+	(Enforce Compatibility Check etc.) into account. In Glyphs 3.1, layerGroups()
+	does not exist yet, so we fall back to the ObjC method it wraps.
+	"""
+	if hasattr(glyph, "layerGroups"):
+		layerGroups = glyph.layerGroups()
+	else:
+		layerGroups = glyph.forcedLayerGroupIdsSeenLayers_(NSMutableSet.set())
+	if not layerGroups:
+		return ()
+	return tuple(tuple(layerGroup) for layerGroup in layerGroups)
 
 
 def getLegibleFont(size=None):


### PR DESCRIPTION
## Quote Manager: flipped components are never auto-aligned

Automatic alignment cannot place a mirrored component reliably, so alignment is now switched off for every component whose transform has a negative determinant (currently the H-mirrored guillemet composite).

- New `componentIsFlipped()` (determinant of the transform matrix, with a `scale` fallback) and `setComponentAlignment()`, which turns automatic alignment on for regular components and sets `automaticAlignment = False` / `disableAlignment = True` for mirrored ones. The component’s current position is read before and restored after, so nothing jumps when alignment is switched off on an existing composite.
- All component creation (double quotes, apostrophe composites, mirrored guillemet) goes through that helper.
- `ensureAutoAlignedComponents()` → `syncComponentAlignment()`: it no longer blindly re-enables alignment on the mirrored guillemet, and reports each component it leaves unaligned in the Macro Window.

## Quote Manager: Update always resets #entry/#exit from the default single quote

- New `ensureDefaultAnchors()` gives the default quote (and the default guillemet) `#entry`/`#exit` in every master if they are missing.
- `update()` now calls it before `syncAnchorsFromDefault()`, so pressing **Update** always resets the cursive attachment anchors of all selected singles from the default single quote, instead of only doing so when the default happened to have anchors already.
- `build()` and `editSingles()` use the same helper instead of their own inline loops.
- Update button tooltip mentions the anchor reset.

Paths are still never overwritten by Update.

## Compatibility runs: use `layerGroups()` instead of grouping by instances

Following Georg’s note that Glyphs 3 and 4 do not determine the groups from the instances by default (Enforce Compatibility Check etc.), and that `glyph.layerGroups()` is the better call when all masters are used anyway, since it checks the relevant parameters:

- New shared helper `layerGroupsOf(glyph)` in `__init__.py` returns the interpolation-compatible layer ID groups as tuples, falling back to `forcedLayerGroupIdsSeenLayers_()` in Glyphs 3.1, where `layerGroups()` does not exist yet. Documented in the utility table in `CLAUDE.md`.
- `Interpolation/Dekink Masters.py` uses it instead of `layerGroups_masters_error_(NSArray(instances), NSArray(currentFont.masters), None)`.
- `Components/Sync Components Across Masters.py` uses it instead of its local 3.1 shim, which the helper now replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rCoMyVFq5KDoS69DuCUSd